### PR TITLE
Fix unhandled error when missing release args and fix use of uninitialized name value

### DIFF
--- a/cmd/release.js
+++ b/cmd/release.js
@@ -16,7 +16,7 @@ module.exports = (ipc) => async function release (args) {
   try {
     const [from] = _
     let [, dir = ''] = _
-    const isKey = parse.runkey(from.toString()).key !== null
+    const isKey = from && parse.runkey(from.toString()).key !== null
     const channel = isKey ? null : from
     const key = isKey ? from : null
     if (!channel && !key) throw new InputError('A key or the channel name must be specified.')

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -517,11 +517,11 @@ class Engine extends ReadyResource {
 
       await this.ready()
 
-      name = name || ctx.name
+      name = name || ctx.manifest?.pear?.name || ctx.manifest?.holepunch?.name || ctx.manifest?.name
 
       yield { tag: 'releasing', data: { name, channel: channelName } }
 
-      const corestore = this.#getCorestore(name || ctx.name, channel, { writable: true })
+      const corestore = this.#getCorestore(name, channel, { writable: true })
 
       const bundle = new Bundle({ corestore, channel, key })
       await session.add(bundle)
@@ -559,7 +559,9 @@ class Engine extends ReadyResource {
 
       if (key) key = hypercoreid.decode(key)
 
-      const corestore = this.#getCorestore(name || ctx.name, channel, { writable: true })
+      name = name || ctx.manifest?.pear?.name || ctx.manifest?.holepunch?.name || ctx.manifest?.name
+
+      const corestore = this.#getCorestore(name, channel, { writable: true })
       const bundle = new Bundle({
         key,
         corestore,


### PR DESCRIPTION
## Changes:
- In both stage and release, `ctx.name` is used while it's still uninitialized causing `null` to be displayed as the app name (as described in #36). This fixes this by not using the context name and deriving the name directly.
- When running `pear release` without a specified key, a `Error: Cannot read properties of undefined (reading 'toString')` error is thrown instead of cleanly showing the "A key or the channel name must be specified." error. This fixes that by skipping the parsing when the passed argument is null/undefined/empty.