### PR TITLE
Add call to updateNotify when running `pear release`

### DIFF
--- a/lib/engine.js
+++ b/lib/engine.js
@@ -543,6 +543,10 @@ class Engine extends ReadyResource {
 
       await bundle.db.put('release', releaseLength)
 
+      await this.sidecar.updateNotify({
+        key: bundle.hexKey, length: bundle.drive.version, fork: bundle.drive.core.fork
+      }, true)
+
       yield { tag: 'released', data: { name, channel, length: bundle.db.feed.length } }
 
       yield { tag: 'final', data: { success: true } }


### PR DESCRIPTION
## Description
[bundle.#updates](https://github.com/holepunchto/pear/blob/6b1c0b85961da114123dafd011d067f4f004b4eb/lib/bundle.js#L77-L83) which uses `drive.watch()` only calls updateNotify when there are file changes. Because of this, it doesn't get triggered it when doing `pear release`.

## Changes
This adds an updateNotify call during `pear release`.