### PR TITLE
fix exit code at pretest runner

### DIFF
--- a/scripts/pretest.js
+++ b/scripts/pretest.js
@@ -25,7 +25,7 @@ const run = (cmd, args, opts) => {
     const child = spawn(cmd, args, opts)
 
     child.on('close', (code) => {
-      if (code === 0) {
+      if (code === 0 || code === null) {
         resolve()
       } else {
         reject(new Error(`Command failed with code ${code}`))


### PR DESCRIPTION
exit code can be null in some platforms, this accepts either code 0 or null to resolve.