### PR TITLE
Make updateNotify sync

### DIFF
--- a/ipc/sidecar.js
+++ b/ipc/sidecar.js
@@ -106,7 +106,7 @@ module.exports = class IPC {
     return this.freelist.from(id) || null
   }
 
-  async updateNotify (version, info = {}) {
+  updateNotify (version, info = {}) {
     this.spindownms = 0
     this.updateAvailable = version
 
@@ -123,7 +123,7 @@ module.exports = class IPC {
     this.#spindownCountdown()
     const messaged = new Set()
 
-    for await (const client of this.clients) {
+    for (const client of this.clients) {
       const app = client?.userData
       if (!app || (app.minvering === true && !version.force)) continue
 


### PR DESCRIPTION
The rest of the code already assumes `updateNotify` is sync, so making it async was most likely an accident

(looping over `this.clients` is sync, so it should not have been an async iterator)