### PR TITLE
fix teardown test close

### DIFF
--- a/test/02-teardown.test.js
+++ b/test/02-teardown.test.js
@@ -36,12 +36,13 @@ test('teardown', async function ({ teardown, is, ok, plan, comment }) {
     })()`)
 
   await inspector.close()
+  await helper.closeClients()
   app.kill('SIGTERM')
 
   const td = await pick.teardown
   is(td, 'teardown', 'teardown has been triggered')
 
-  await helper.close()
+  await helper.shutdown()
 
   const { code } = await pick.exit
   is(code, 130, 'exit code is 130')
@@ -81,12 +82,13 @@ test('teardown during teardown', async function ({ teardown, is, ok, plan, comme
     })()`)
 
   await inspector.close()
+  await helper.closeClients()
   app.kill('SIGTERM')
 
   const td = await pick.teardown
   is(td, 'teardown from b', 'teardown from b has been triggered')
 
-  await helper.close()
+  await helper.shutdown()
 
   const { code } = await pick.exit
   is(code, 130, 'exit code is 130')


### PR DESCRIPTION
This fixes a `channel remotely closed` error happening in the teardown test by closing the clients connected to the helper before forcing the teardown of the fixture terminal app.
