### PR TITLE
reverse changelog order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Pear Runtime Changelog
 
-## v1.0.0
-
-First public release 🍐
-
 ## v1.1.0
 
 ### Features
@@ -31,4 +27,8 @@ First public release 🍐
 - `<pear-ctrl>` added to Desktop example
 - `<pear-ctrl>` added to pear init Desktop template
 - usage: pear run / pear dev clarifications
-- more update flow tests 
+- more update flow tests
+
+## v1.0.0
+
+First public release 🍐

--- a/lib/engine.js
+++ b/lib/engine.js
@@ -788,7 +788,7 @@ class Engine extends ReadyResource {
 
       const contents = await drive.get('/CHANGELOG.md')
 
-      const changelog = await clog.parse(contents).at(-1)?.[1] || '[ No Changelog ]'
+      const changelog = await clog.parse(contents).at(0)?.[1] || '[ No Changelog ]'
 
       yield { tag: 'changelog', data: { changelog } }
     } catch (err) {


### PR DESCRIPTION
- Reverse the changelog's order so that it has most recent changes first (top of the file) which aligns it with Keet's desktop changelog
- Adapt `pear info` logic to align it with this order