### PR TITLE
Fix test plan number

### DIFF
--- a/test/02-teardown.test.js
+++ b/test/02-teardown.test.js
@@ -95,7 +95,7 @@ test('teardown during teardown', async function ({ teardown, is, ok, plan, comme
 })
 
 test('exit code', async function ({ teardown, is, ok, plan, comment }) {
-  plan(4)
+  plan(3)
 
   const helper = new Helper(teardown)
   await helper.bootstrap()


### PR DESCRIPTION
Fixes incorrect test plan  number, which was causing a silent error and stopped the tests from proceeding.