### PR TITLE
Fix URL handling on Windows and Linux

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -2,7 +2,7 @@
 const IPC = require('./ipc/main')
 const Context = require('./ctx/shared')
 const { App } = require('./lib/gui')
-const { SWAP, RUNTIME } = require('./lib/constants')
+const { SWAP, WAKEUP } = require('./lib/constants')
 const crasher = require('./lib/crasher')
 const connect = require('./lib/connect.js')
 const { isWindows, isMac, isLinux } = require('which-runtime')
@@ -42,11 +42,11 @@ async function electronMain () {
 function configureElectron () {
   const electron = require('electron')
   if (isLinux) {
-    linuxSetup(RUNTIME)
+    linuxSetup(WAKEUP)
   }
 
   if (isWindows) {
-    windowsSetup(RUNTIME)
+    windowsSetup(WAKEUP)
   }
 
   const appName = applingName()

--- a/electron-main.js
+++ b/electron-main.js
@@ -6,6 +6,7 @@ const { SWAP, RUNTIME } = require('./lib/constants')
 const crasher = require('./lib/crasher')
 const connect = require('./lib/connect.js')
 const { isWindows, isMac, isLinux } = require('which-runtime')
+const { spawnSync } = require('child_process')
 
 configureElectron()
 crasher('electron-main', SWAP)
@@ -179,7 +180,7 @@ function windowsSetup (executable) {
   const { spawnSync } = require('child_process')
 
   const PROTOCOL = 'pear'
-  const HANDLER_NAME = 'Pear Protocol'
+  const HANDLER_NAME = 'Pear Application'
   const HANDLER_COMMAND = `"${executable}" run "%1"`
 
   const REGISTRY_PATH = `HKCU\\Software\\Classes\\${PROTOCOL}`

--- a/electron-main.js
+++ b/electron-main.js
@@ -1,11 +1,12 @@
 'use strict'
+const { isWindows, isMac, isLinux } = require('which-runtime')
 const IPC = require('./ipc/main')
 const Context = require('./ctx/shared')
 const { App } = require('./lib/gui')
 const { SWAP, WAKEUP } = require('./lib/constants')
 const crasher = require('./lib/crasher')
 const connect = require('./lib/connect.js')
-const { isWindows, isMac, isLinux } = require('which-runtime')
+const registerUrlHandler = require('./lib/url-handler')
 
 configureElectron()
 crasher('electron-main', SWAP)
@@ -41,13 +42,8 @@ async function electronMain () {
 
 function configureElectron () {
   const electron = require('electron')
-  if (isLinux) {
-    linuxSetup(WAKEUP)
-  }
 
-  if (isWindows) {
-    windowsSetup(WAKEUP)
-  }
+  registerUrlHandler(WAKEUP)
 
   const appName = applingName()
   if (appName) {
@@ -102,103 +98,4 @@ function applingName () {
   }
 
   return null
-}
-
-function linuxSetup (executable) {
-  const fs = require('fs')
-  const os = require('os')
-  const { join } = require('path')
-  const { spawnSync } = require('child_process')
-  const APP_NAME = 'Pear'
-  const ICON_NAME = 'pear'
-  const DESKTOP_FILE_NAME = 'pear.desktop'
-  const DESKTOP_FILE_PATH = join(os.homedir(), '.local', 'share', 'applications', DESKTOP_FILE_NAME)
-  const MIME_TYPES = [
-    'x-scheme-handler/pear' // pear
-  ]
-
-  if (!executable) return
-  try {
-    if (!checkDesktopFile(executable)) {
-      fs.writeFileSync(DESKTOP_FILE_PATH, generateDesktopFile(executable), { encoding: 'utf-8' })
-    }
-    for (const mimeType of MIME_TYPES) {
-      if (!checkMimeType(mimeType)) {
-        registerMimeType(mimeType)
-      }
-    }
-  } catch (err) {
-    console.warn('could not install protocol handler:', err)
-  }
-
-  function checkDesktopFile () {
-    try {
-      return fs.readFileSync(DESKTOP_FILE_PATH, 'utf-8').includes(`Exec=${executable} run %U`)
-    } catch (err) {
-      if (err.code !== 'ENOENT') throw err
-      return false
-    }
-  }
-
-  function checkMimeType (mimeType) {
-    try {
-      return spawnSync('xdg-mime', ['query', 'default', mimeType]).stdout.toString() === DESKTOP_FILE_NAME
-    } catch {
-      return false
-    }
-  }
-
-  function registerMimeType (mimeType) {
-    try {
-      spawnSync('xdg-mime', ['default', DESKTOP_FILE_NAME, mimeType])
-      return true
-    } catch {
-      return false
-    }
-  }
-
-  function generateDesktopFile (executable) {
-    return `\
-[Desktop Entry]
-Name=${APP_NAME}
-Exec=${executable} %U
-Terminal=false
-Icon=${ICON_NAME}
-Type=Application
-StartupWMClass=${APP_NAME}
-X-AppImage-Version=1.0.1
-Comment=${APP_NAME}
-MimeType=${MIME_TYPES.join(';')};
-NoDisplay=true
-`
-  }
-}
-
-function windowsSetup (executable) {
-  if (!executable) return
-
-  const { spawnSync } = require('child_process')
-
-  const PROTOCOL = 'pear'
-  const HANDLER_NAME = 'Pear Application'
-  const HANDLER_COMMAND = `"${executable}" "%1"`
-
-  const REGISTRY_PATH = `HKCU\\Software\\Classes\\${PROTOCOL}`
-  const REGISTRY_COMMAND_PATH = `${REGISTRY_PATH}\\shell\\open\\command`
-
-  try {
-    if (spawnSync('reg', ['query', REGISTRY_PATH, '/v', 'URL Protocol']).status !== 0) {
-      spawnSync('reg', ['add', REGISTRY_PATH, '/v', 'URL Protocol', '/t', 'REG_SZ', '/d', '', '/f'])
-      spawnSync('reg', ['add', REGISTRY_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_NAME, '/f'])
-    }
-
-    const currentHandler = spawnSync('reg', ['query', REGISTRY_COMMAND_PATH])
-      .stdout.toString()?.match(/REG_SZ\s+"([^"]+)"/)?.[1]
-
-    if (currentHandler !== HANDLER_COMMAND) {
-      spawnSync('reg', ['add', REGISTRY_COMMAND_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_COMMAND, '/f'])
-    }
-  } catch (err) {
-    console.warn('could not install protocol handler:', err)
-  }
 }

--- a/electron-main.js
+++ b/electron-main.js
@@ -169,6 +169,7 @@ StartupWMClass=${APP_NAME}
 X-AppImage-Version=1.0.1
 Comment=${APP_NAME}
 MimeType=${MIME_TYPES.join(';')};
+NoDisplay=true
 `
   }
 }

--- a/electron-main.js
+++ b/electron-main.js
@@ -160,17 +160,17 @@ function linuxSetup (executable) {
 
   function generateDesktopFile (executable) {
     return `\
-  [Desktop Entry]
-  Name=${APP_NAME}
-  Exec=${executable} %U
-  Terminal=false
-  Icon=${ICON_NAME}
-  Type=Application
-  StartupWMClass=${APP_NAME}
-  X-AppImage-Version=1.0.1
-  Comment=${APP_NAME}
-  MimeType=${MIME_TYPES.join(';')}
-  `
+[Desktop Entry]
+Name=${APP_NAME}
+Exec=${executable} run %U
+Terminal=false
+Icon=${ICON_NAME}
+Type=Application
+StartupWMClass=${APP_NAME}
+X-AppImage-Version=1.0.1
+Comment=${APP_NAME}
+MimeType=${MIME_TYPES.join(';')}
+`
   }
 }
 

--- a/electron-main.js
+++ b/electron-main.js
@@ -169,7 +169,7 @@ Type=Application
 StartupWMClass=${APP_NAME}
 X-AppImage-Version=1.0.1
 Comment=${APP_NAME}
-MimeType=${MIME_TYPES.join(';')}
+MimeType=${MIME_TYPES.join(';')};
 `
   }
 }

--- a/electron-main.js
+++ b/electron-main.js
@@ -187,11 +187,17 @@ function windowsSetup (executable) {
   const REGISTRY_COMMAND_PATH = `${REGISTRY_PATH}\\shell\\open\\command`
 
   try {
-    if (spawnSync('reg', ['query', REGISTRY_PATH]).status === 0) return
+    if (spawnSync('reg', ['query', REGISTRY_PATH, '/v', 'URL Protocol']).status !== 0) {
+      spawnSync('reg', ['add', REGISTRY_PATH, '/v', 'URL Protocol', '/t', 'REG_SZ', '/d', '', '/f'])
+      spawnSync('reg', ['add', REGISTRY_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_NAME, '/f'])
+    }
 
-    spawnSync('reg', ['add', REGISTRY_PATH, '/v', 'URL Protocol', '/t', 'REG_SZ', '/d', '', '/f'])
-    spawnSync('reg', ['add', REGISTRY_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_NAME, '/f'])
-    spawnSync('reg', ['add', REGISTRY_COMMAND_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_COMMAND, '/f'])
+    const currentHandler = spawnSync('reg', ['query', REGISTRY_COMMAND_PATH])
+      .stdout.toString()?.match(/REG_SZ\s+"([^"]+)"/)?.[1]
+
+    if (currentHandler !== HANDLER_COMMAND) {
+      spawnSync('reg', ['add', REGISTRY_COMMAND_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_COMMAND, '/f'])
+    }
   } catch (err) {
     console.warn('could not install protocol handler:', err)
   }

--- a/electron-main.js
+++ b/electron-main.js
@@ -161,7 +161,7 @@ function linuxSetup (executable) {
     return `\
 [Desktop Entry]
 Name=${APP_NAME}
-Exec=${executable} run %U
+Exec=${executable} %U
 Terminal=false
 Icon=${ICON_NAME}
 Type=Application
@@ -180,7 +180,7 @@ function windowsSetup (executable) {
 
   const PROTOCOL = 'pear'
   const HANDLER_NAME = 'Pear Application'
-  const HANDLER_COMMAND = `"${executable}" run "%1"`
+  const HANDLER_COMMAND = `"${executable}" "%1"`
 
   const REGISTRY_PATH = `HKCU\\Software\\Classes\\${PROTOCOL}`
   const REGISTRY_COMMAND_PATH = `${REGISTRY_PATH}\\shell\\open\\command`

--- a/electron-main.js
+++ b/electron-main.js
@@ -6,7 +6,6 @@ const { SWAP, RUNTIME } = require('./lib/constants')
 const crasher = require('./lib/crasher')
 const connect = require('./lib/connect.js')
 const { isWindows, isMac, isLinux } = require('which-runtime')
-const { spawnSync } = require('child_process')
 
 configureElectron()
 crasher('electron-main', SWAP)

--- a/electron-main.js
+++ b/electron-main.js
@@ -3,10 +3,9 @@ const { isWindows, isMac, isLinux } = require('which-runtime')
 const IPC = require('./ipc/main')
 const Context = require('./ctx/shared')
 const { App } = require('./lib/gui')
-const { SWAP, WAKEUP } = require('./lib/constants')
+const { SWAP } = require('./lib/constants')
 const crasher = require('./lib/crasher')
 const connect = require('./lib/connect.js')
-const registerUrlHandler = require('./lib/url-handler')
 
 configureElectron()
 crasher('electron-main', SWAP)
@@ -42,8 +41,6 @@ async function electronMain () {
 
 function configureElectron () {
   const electron = require('electron')
-
-  registerUrlHandler(WAKEUP)
 
   const appName = applingName()
   if (appName) {

--- a/electron-main.js
+++ b/electron-main.js
@@ -109,9 +109,9 @@ function linuxSetup (executable) {
   const os = require('os')
   const { join } = require('path')
   const { spawnSync } = require('child_process')
-  const APP_NAME = 'Keet'
-  const ICON_NAME = 'keet'
-  const DESKTOP_FILE_NAME = 'keet.desktop'
+  const APP_NAME = 'Pear'
+  const ICON_NAME = 'pear'
+  const DESKTOP_FILE_NAME = 'pear.desktop'
   const DESKTOP_FILE_PATH = join(os.homedir(), '.local', 'share', 'applications', DESKTOP_FILE_NAME)
   const MIME_TYPES = [
     'x-scheme-handler/pear' // pear

--- a/electron-main.js
+++ b/electron-main.js
@@ -133,8 +133,7 @@ function linuxSetup (executable) {
 
   function checkDesktopFile () {
     try {
-      fs.statSync(DESKTOP_FILE_PATH)
-      return true
+      return fs.readFileSync(DESKTOP_FILE_PATH, 'utf-8').includes(`Exec=${executable} run %U`)
     } catch (err) {
       if (err.code !== 'ENOENT') throw err
       return false

--- a/electron-main.js
+++ b/electron-main.js
@@ -180,7 +180,7 @@ function windowsSetup (executable) {
 
   const PROTOCOL = 'pear'
   const HANDLER_NAME = 'Pear Protocol'
-  const HANDLER_COMMAND = `"${executable}" "%1"`
+  const HANDLER_COMMAND = `"${executable}" run "%1"`
 
   const REGISTRY_PATH = `HKCU\\Software\\Classes\\${PROTOCOL}`
   const REGISTRY_COMMAND_PATH = `${REGISTRY_PATH}\\shell\\open\\command`

--- a/lib/url-handler.js
+++ b/lib/url-handler.js
@@ -15,6 +15,8 @@ function registerLinuxHandler (executable) {
   const { join } = require('bare-path')
   const { spawnSync } = require('bare-subprocess')
 
+  if (!checkXdgMime()) return
+
   const APP_NAME = 'Pear'
   const ICON_NAME = 'pear'
   const DESKTOP_FILE_NAME = 'pear.desktop'
@@ -37,6 +39,15 @@ function registerLinuxHandler (executable) {
     }
   } catch (err) {
     console.error('could not install protocol handler:', err)
+  }
+
+  function checkXdgMime () {
+    try {
+      spawnSync('xdg-mime', ['--version'])
+      return true
+    } catch (err) {
+      return false
+    }
   }
 
   function checkExists (path) {

--- a/lib/url-handler.js
+++ b/lib/url-handler.js
@@ -98,7 +98,7 @@ function registerWindowsHandler (executable) {
     const currentHandler = spawnSync('reg', ['query', REGISTRY_COMMAND_PATH])
       .stdout.toString()?.match(/REG_SZ\s+"([^"]+)"/)?.[1]
 
-    if (currentHandler !== HANDLER_COMMAND) {
+    if (currentHandler !== executable) {
       spawnSync('reg', ['add', REGISTRY_COMMAND_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_COMMAND, '/f'])
     }
   } catch (err) {

--- a/lib/url-handler.js
+++ b/lib/url-handler.js
@@ -10,10 +10,10 @@ module.exports = function register (executable) {
 function registerLinuxHandler (executable) {
   if (!executable) return
 
-  const fs = require('fs')
-  const os = require('os')
-  const { join } = require('path')
-  const { spawnSync } = require('child_process')
+  const fs = require('bare-fs')
+  const os = require('bare-os')
+  const { join } = require('bare-path')
+  const { spawnSync } = require('bare-subprocess')
 
   const APP_NAME = 'Pear'
   const ICON_NAME = 'pear'
@@ -80,7 +80,7 @@ NoDisplay=true
 function registerWindowsHandler (executable) {
   if (!executable) return
 
-  const { spawnSync } = require('child_process')
+  const { spawnSync } = require('bare-subprocess')
 
   const PROTOCOL = 'pear'
   const HANDLER_NAME = 'Pear Application'

--- a/lib/url-handler.js
+++ b/lib/url-handler.js
@@ -18,10 +18,15 @@ function registerLinuxHandler (executable) {
   const APP_NAME = 'Pear'
   const ICON_NAME = 'pear'
   const DESKTOP_FILE_NAME = 'pear.desktop'
-  const DESKTOP_FILE_PATH = join(os.homedir(), '.local', 'share', 'applications', DESKTOP_FILE_NAME)
+  const APPLICATIONS_DIR = join(os.homedir(), '.local', 'share', 'applications')
+  const DESKTOP_FILE_PATH = join(APPLICATIONS_DIR, DESKTOP_FILE_NAME)
   const MIME_TYPES = ['x-scheme-handler/pear']
 
   try {
+    if (!checkExists(APPLICATIONS_DIR)) {
+      fs.mkdirSync(APPLICATIONS_DIR, { recursive: true })
+    }
+
     if (!checkDesktopFile(executable)) {
       fs.writeFileSync(DESKTOP_FILE_PATH, generateDesktopFile(executable), { encoding: 'utf-8' })
     }
@@ -32,6 +37,15 @@ function registerLinuxHandler (executable) {
     }
   } catch (err) {
     console.error('could not install protocol handler:', err)
+  }
+
+  function checkExists (path) {
+    try {
+      fs.accessSync(path)
+      return true
+    } catch (err) {
+      return false
+    }
   }
 
   function checkDesktopFile () {

--- a/lib/url-handler.js
+++ b/lib/url-handler.js
@@ -31,7 +31,7 @@ function registerLinuxHandler (executable) {
       }
     }
   } catch (err) {
-    console.warn('could not install protocol handler:', err)
+    console.error('could not install protocol handler:', err)
   }
 
   function checkDesktopFile () {
@@ -102,6 +102,6 @@ function registerWindowsHandler (executable) {
       spawnSync('reg', ['add', REGISTRY_COMMAND_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_COMMAND, '/f'])
     }
   } catch (err) {
-    console.warn('could not install protocol handler:', err)
+    console.error('could not install protocol handler:', err)
   }
 }

--- a/lib/url-handler.js
+++ b/lib/url-handler.js
@@ -1,0 +1,107 @@
+'use strict'
+
+const { isWindows, isLinux } = require('which-runtime')
+
+module.exports = function register (executable) {
+  if (isLinux) registerLinuxHandler(executable)
+  if (isWindows) registerWindowsHandler(executable)
+}
+
+function registerLinuxHandler (executable) {
+  if (!executable) return
+
+  const fs = require('fs')
+  const os = require('os')
+  const { join } = require('path')
+  const { spawnSync } = require('child_process')
+
+  const APP_NAME = 'Pear'
+  const ICON_NAME = 'pear'
+  const DESKTOP_FILE_NAME = 'pear.desktop'
+  const DESKTOP_FILE_PATH = join(os.homedir(), '.local', 'share', 'applications', DESKTOP_FILE_NAME)
+  const MIME_TYPES = ['x-scheme-handler/pear']
+
+  try {
+    if (!checkDesktopFile(executable)) {
+      fs.writeFileSync(DESKTOP_FILE_PATH, generateDesktopFile(executable), { encoding: 'utf-8' })
+    }
+    for (const mimeType of MIME_TYPES) {
+      if (!checkMimeType(mimeType)) {
+        registerMimeType(mimeType)
+      }
+    }
+  } catch (err) {
+    console.warn('could not install protocol handler:', err)
+  }
+
+  function checkDesktopFile () {
+    try {
+      return fs.readFileSync(DESKTOP_FILE_PATH, 'utf-8').includes(`Exec=${executable} run %U`)
+    } catch (err) {
+      if (err.code !== 'ENOENT') throw err
+      return false
+    }
+  }
+
+  function checkMimeType (mimeType) {
+    try {
+      return spawnSync('xdg-mime', ['query', 'default', mimeType]).stdout.toString() === DESKTOP_FILE_NAME
+    } catch {
+      return false
+    }
+  }
+
+  function registerMimeType (mimeType) {
+    try {
+      spawnSync('xdg-mime', ['default', DESKTOP_FILE_NAME, mimeType])
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  function generateDesktopFile (executable) {
+    return `\
+[Desktop Entry]
+Name=${APP_NAME}
+Exec=${executable} %U
+Terminal=false
+Icon=${ICON_NAME}
+Type=Application
+StartupWMClass=${APP_NAME}
+X-AppImage-Version=1.0.1
+Comment=${APP_NAME}
+MimeType=${MIME_TYPES.join(';')};
+NoDisplay=true
+`
+  }
+}
+
+function registerWindowsHandler (executable) {
+  if (!executable) return
+
+  const { spawnSync } = require('child_process')
+
+  const PROTOCOL = 'pear'
+  const HANDLER_NAME = 'Pear Application'
+  const HANDLER_COMMAND = `"${executable}" "%1"`
+
+  const REGISTRY_PATH = `HKCU\\Software\\Classes\\${PROTOCOL}`
+  const REGISTRY_COMMAND_PATH = `${REGISTRY_PATH}\\shell\\open\\command`
+
+  try {
+    if (spawnSync('reg', ['query', REGISTRY_PATH, '/v', 'URL Protocol']).status !== 0) {
+      spawnSync('reg', ['add', REGISTRY_PATH, '/v', 'URL Protocol', '/t', 'REG_SZ', '/d', '', '/f'])
+      spawnSync('reg', ['add', REGISTRY_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_NAME, '/f'])
+    }
+
+    const currentHandler = spawnSync('reg', ['query', REGISTRY_COMMAND_PATH])
+      .stdout.toString()?.match(/REG_SZ\s+"([^"]+)"/)?.[1]
+
+    if (currentHandler !== HANDLER_COMMAND) {
+      spawnSync('reg', ['add', REGISTRY_COMMAND_PATH, '/v', '', '/t', 'REG_SZ', '/d', HANDLER_COMMAND, '/f'])
+    }
+  } catch (err) {
+    console.warn('could not install protocol handler:', err)
+  }
+}

--- a/sidecar.js
+++ b/sidecar.js
@@ -5,7 +5,16 @@ const Hyperdrive = require('hyperdrive')
 const HypercoreID = require('hypercore-id-encoding')
 const subsystem = require('./lib/subsystem.js')
 const crasher = require('./lib/crasher')
-const { SWAP, PLATFORM_CORESTORE, CHECKOUT, LOCALDEV, UPGRADE_LOCK, PLATFORM_DIR } = require('./lib/constants.js')
+const {
+  SWAP,
+  PLATFORM_CORESTORE,
+  CHECKOUT,
+  LOCALDEV,
+  UPGRADE_LOCK,
+  PLATFORM_DIR,
+  WAKEUP
+} = require('./lib/constants.js')
+const registerUrlHandler = require('./lib/url-handler')
 
 crasher('sidecar', SWAP)
 module.exports = bootSidecar().catch((err) => {
@@ -23,6 +32,8 @@ async function bootSidecar () {
   const updater = createUpdater()
   const sidecar = new SidecarIPC({ updater, drive, corestore })
   await sidecar.listen()
+
+  registerUrlHandler(WAKEUP)
 
   function createUpdater () {
     if (LOCALDEV) return null


### PR DESCRIPTION
## Changes
- Fix issues with the Linux desktop file
- Ensure that the executable path is up to date on Linux
- Replace electron-based URL registration (broken) on Windows with inserts to the registry
- Switch to the WAKEUP command instead of RUNTIME
- Added line to hide desktop entry from the user's application menu on Linux

## Notes
~~Since the pear-runtime.exe in Windows is a console application, running it spawns a console window before it launches the application window.~~ (fixed by switch to WAKEUP command)