### PR TITLE
Sidecar boot log

### DIFF
--- a/cmd/sidecar.js
+++ b/cmd/sidecar.js
@@ -27,6 +27,7 @@ module.exports = (ipc) => async function sidecar (args) {
 
   Bare.argv.push('--spindown-timeout=2147483647', ...args)
   Bare.argv.push('--runtime', RUNTIME)
+  if (!Bare.argv.includes('--verbose')) Bare.argv.push('--verbose')
 
   require('../sidecar')
 

--- a/cmd/usage.js
+++ b/cmd/usage.js
@@ -151,7 +151,7 @@ module.exports = ({ fork, length, key }) => {
     and then becomes the sidecar.
 
     --mem              memory mode: RAM corestore
-    --attach-boot-io   include initial sidecar I/O (if applicable)
+    --verbose          Additional output
   `
 
   const versions = ansi.bold(cmd + ' versions')

--- a/lib/sidecar.js
+++ b/lib/sidecar.js
@@ -47,12 +47,14 @@ class Sidecar {
   decomissioned = false
   #closed = null
   updateAvailable = null
+  verbose = false
 
   teardown () {
     global.Bare.exit()
   }
 
   constructor ({ updater, drive, corestore }) {
+    this.verbose = parse.args(global.Bare.argv, { boolean: ['verbose'] }).verbose
     this.updater = updater
     if (this.updater) {
       this.updater.on('update', (checkout) => this.updateNotify(checkout))
@@ -77,7 +79,7 @@ class Sidecar {
 
     let closed = null
     this.closing = new Promise((resolve) => { closed = resolve })
-    this.closing.finally(() => console.log((isWindows ? '^' : '✔') + ' Sidecar closed'))
+    this.closing.finally(() => { if (this.verbose) console.log((isWindows ? '^' : '✔') + ' Sidecar closed') })
     this.#closed = closed
     this.#spindownCountdown()
   }
@@ -110,15 +112,16 @@ class Sidecar {
     this.spindownms = 0
     this.updateAvailable = { version, info }
 
-    if (info.link) {
-      console.log('Application update available:')
-    } else if (version.force) {
-      console.log('Platform Force update (' + version.force.reason + '). Updating to:')
-    } else {
-      console.log('Platform update Available. Restart to update to:')
+    if (this.verbose) {
+      if (info.link) {
+        console.log('Application update available:')
+      } else if (version.force) {
+        console.log('Platform Force update (' + version.force.reason + '). Updating to:')
+      } else {
+        console.log('Platform update Available. Restart to update to:')
+      }
+      console.log('  v' + version.fork + '.' + version.length + '.' + version.key)
     }
-
-    console.log('  v' + version.fork + '.' + version.length + '.' + version.key)
 
     this.#spindownCountdown()
     const messaged = new Set()
@@ -167,7 +170,7 @@ class Sidecar {
   }
 
   async restart ({ platform = false } = {}, client) {
-    console.log('Restarting ' + (platform ? 'platform' : 'client'))
+    if (this.verbose) console.log('Restarting ' + (platform ? 'platform' : 'client'))
     if (platform === false) {
       const { cwd, runtime, argv, env } = client.userData.ctx
       const appling = client.userData.ctx.appling
@@ -200,7 +203,7 @@ class Sidecar {
     // shutdown successful, reset death clock
     this.deathClock()
     if (restarts.length === 0) return
-    console.log('Restarting', restarts.length, 'apps')
+    if (this.verbose) console.log('Restarting', restarts.length, 'apps')
     for (const { cwd, appling, argv, env } of restarts) {
       const opts = { cwd, env, detached: true, stdio: 'ignore' }
       if (appling) {
@@ -231,7 +234,7 @@ class Sidecar {
   }
 
   async shutdown (client) {
-    console.log('- Sidecar shutting down...')
+    if (this.verbose) console.log('- Sidecar shutting down...')
     const app = client.userData
     const tearingDown = !!app && app.teardown()
     if (tearingDown === false) client.close()
@@ -257,7 +260,7 @@ class Sidecar {
     await this.ipc.close()
     if (this.updater) {
       if (await this.updater.applyUpdate() !== null) {
-        console.log((isWindows ? '^' : '✔') + ' Applied update')
+        if (this.verbose) console.log((isWindows ? '^' : '✔') + ' Applied update')
       }
     }
     this.#closed()

--- a/lib/tryboot.js
+++ b/lib/tryboot.js
@@ -6,7 +6,7 @@ const { RUNTIME, PLATFORM_DIR } = require('./constants.js')
 module.exports = function tryboot () {
   const sc = spawn(RUNTIME, ['--sidecar'], {
     detached: true,
-    stdio: (global.Bare || global.process).argv.includes('--attach-boot-io') ? 'inherit' : 'ignore',
+    stdio: (global.Bare || global.process).argv.includes('--verbose') ? 'inherit' : 'ignore',
     cwd: PLATFORM_DIR
   })
 

--- a/scripts/pretest.js
+++ b/scripts/pretest.js
@@ -45,5 +45,5 @@ const run = (cmd, args, opts) => {
     }
   }
 
-  await run(pear, ['run', 'test', '--attach-boot-io'], { stdio: 'inherit', shell: isWindows })
+  await run(pear, ['run', 'test', '--verbose'], { stdio: 'inherit', shell: isWindows })
 })()

--- a/sidecar.js
+++ b/sidecar.js
@@ -15,9 +15,13 @@ const {
   WAKEUP
 } = require('./lib/constants.js')
 const registerUrlHandler = require('./lib/url-handler')
+const parse = require('./lib/parse')
+const { verbose } = parse.args(Bare.argv, { boolean: ['verbose'] })
 
 crasher('sidecar', SWAP)
-module.exports = bootSidecar().catch((err) => {
+module.exports = bootSidecar().then(() => {
+  if (verbose) console.log('- Sidecar booted')
+}).catch((err) => {
   console.error(err.stack)
   Bare.exit(1)
 })

--- a/test/helper.js
+++ b/test/helper.js
@@ -32,8 +32,6 @@ class Helper {
     this.socketPath = isWindows ? `\\\\.\\pipe\\${Helper.IPC_ID}` : `${this.platformDir}/${Helper.IPC_ID}.sock`
     this.bin = 'by-arch/' + platform + '-' + arch + '/bin/'
     this.runtime = path.join(this.swap, 'by-arch', platform + '-' + arch, 'bin', 'pear-runtime')
-
-    if (this.logging) this.argv.push('--attach-boot-io')
   }
 
   static IPC_ID = 'pear'
@@ -89,6 +87,7 @@ class Helper {
     }
 
     function onconnect () {
+      console.log('- Bootpipe connected to sidecar')
       pipe.removeListener('error', onerror)
       pipe.removeListener('connect', onconnect)
       clearTimeout(timeout)


### PR DESCRIPTION
Replaces `--attach-boot-io` with `--verbose` flag.
Sets `--verbose` flag by default so that `pear sidecar` command runs with verbose logs enabled.
`pear --sidecar` runs silent by default with the option of running `pear --sidecar --verbose`.
Adds a log at sidecar startup.