### PR TITLE
Pear.updates shutdown

### DIFF
--- a/test/helper.js
+++ b/test/helper.js
@@ -9,7 +9,6 @@ const { arch, platform, isWindows } = require('which-runtime')
 const { Session } = require('pear-inspect')
 const { Readable } = require('streamx')
 const IPC = require('pear-ipc')
-const Localdrive = require('localdrive')
 const HOST = platform + '-' + arch
 const BY_ARCH = path.join('by-arch', HOST, 'bin', `pear-runtime${isWindows ? '.exe' : ''}`)
 const PLATFORM_DIR = path.join(os.cwd(), '..', 'pear')
@@ -162,36 +161,6 @@ class Helper extends IPC {
 
   async sleep (ms) {
     return new Promise(resolve => setTimeout(resolve, ms))
-  }
-
-  static Mirror = class extends ReadyResource {
-    constructor ({ src = null, dest = null } = {}) {
-      super()
-      this.srcDir = src
-      this.destDir = dest
-    }
-
-    async _open () {
-      this.srcDrive = new Localdrive(this.srcDir)
-      this.destDrive = new Localdrive(this.destDir)
-
-      const mirror = this.srcDrive.mirror(this.destDrive, {
-        filter: (key) => {
-          return !key.startsWith('.git')
-        }
-      })
-
-      await mirror.done()
-    }
-
-    async _close () {
-      await this.srcDrive.close()
-      await this.destDrive.close()
-    }
-
-    get drive () {
-      return this.destDrive
-    }
   }
 
   static Inspector = class extends ReadyResource {

--- a/test/helper.js
+++ b/test/helper.js
@@ -35,7 +35,6 @@ class Helper extends IPC {
           }
     })
     this.#expectSidecar = opts.expectSidecar
-    this.platformDir = platformDir
     this.opts = opts
   }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -29,12 +29,13 @@ class Helper extends IPC {
             const sc = spawn(
               runtime, ['--sidecar', '--verbose'], {
                 detached: true,
-                inherit: true
+                stdio: opts.logging ? 'inherit' : 'ignore'
               })
             sc.unref()
           }
     })
     this.#expectSidecar = opts.expectSidecar
+    this.logging = opts.logging
     this.opts = opts
   }
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -12,13 +12,13 @@ const IPC = require('pear-ipc')
 const Localdrive = require('localdrive')
 const HOST = platform + '-' + arch
 const BY_ARCH = path.join('by-arch', HOST, 'bin', `pear-runtime${isWindows ? '.exe' : ''}`)
-const RUNTIME = path.join(os.cwd(), '..', BY_ARCH)
+const PLATFORM_DIR = path.join(os.cwd(), '..', 'pear')
 
 class Helper extends IPC {
   #expectSidecar = false
 
   constructor (opts = {}) {
-    const platformDir = opts.platformDir || path.resolve(os.cwd(), '..', 'pear')
+    const platformDir = opts.platformDir || PLATFORM_DIR
     const runtime = path.join(platformDir, '..', BY_ARCH)
 
     super({
@@ -36,16 +36,17 @@ class Helper extends IPC {
           }
     })
     this.#expectSidecar = opts.expectSidecar
-    this.runtime = runtime
+    this.platformDir = platformDir
     this.opts = opts
   }
 
   static logging = false
 
-  static async open (key, { tags = [], runtime = RUNTIME } = {}, opts = {}) {
+  static async open (key, { tags = [] } = {}, opts = {}) {
     if (!key) throw new Error('Key is missing')
     const args = ['run', key.startsWith('pear://') ? key : `pear://${key}`]
 
+    const runtime = path.join(opts.platformDir || PLATFORM_DIR, '..', BY_ARCH)
     const subprocess = spawn(runtime, args, { stdio: ['pipe', 'pipe', 'inherit'] })
     tags = ['inspector', ...tags].map((tag) => ({ tag }))
 


### PR DESCRIPTION
This PR fixes an issue with the shutdown process in the pear updater test.

Changes:
- Custom platform dir: creates a fresh localdev platform dir and enables the option to pass this custom dir to the Helper. This allows the pear updater test to operate on a separate pear instance
- Releaser shutdown: adds the releaser shutdown during teardown phase