### PR TITLE
copy/paste text only using right-click

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -299,13 +299,12 @@ function refresh (webContents, ctx) {
 }
 
 class ContextMenu {
-  constructor (webContents, { devtools } = {}) {
+  constructor (webContents) {
     this.webContents = webContents
-    this.devtools = devtools
     webContents.once('destroyed', () => this.destroy())
   }
 
-  async popup (params) {
+  async popup ({ params, devtools = false }) {
     const items = []
 
     const {
@@ -330,7 +329,7 @@ class ContextMenu {
       }))
     }
 
-    if (this.devtools) {
+    if (devtools) {
       items.push(new electron.MenuItem({
         label: 'Inspect Element',
         click: () => {
@@ -413,8 +412,8 @@ class App {
         const ctrl = PearGUI.fromWebContents(wc)
         if (!ctrl) return
         if ((ctrl.view && ctrl.view.webContents === wc) || (ctrl.view === null && ctrl.win?.webContents === wc)) {
-          this.contextMenu = this.contextMenu || new ContextMenu(wc, { dev: this.ctx.devtools })
-          this.contextMenu.popup(params)
+          this.contextMenu = this.contextMenu || new ContextMenu(wc)
+          this.contextMenu.popup({ params, devtools: this.ctx.devtools })
         }
       })
       wc.on('render-process-gone', async (evt, details) => {

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -302,18 +302,31 @@ class ContextMenu {
   constructor (webContents, { devtools } = {}) {
     this.webContents = webContents
     this.devtools = devtools
-    this.x = 0
-    this.y = 0
     webContents.once('destroyed', () => this.destroy())
   }
 
-  async popup ({ x = 0, y = 0 } = {}) {
+  async popup (params) {
     const items = []
 
-    if (await this.webContents.executeJavaScript(`document.elementFromPoint(${x}, ${y})?.tagName === 'IMG'`)) {
+    const {
+      editFlags: { canPaste },
+      isEditable,
+      selectionText,
+      x = 0,
+      y = 0
+    } = params
+
+    if (selectionText) {
       items.push(new electron.MenuItem({
-        label: 'Copy Image',
-        click: () => this.webContents.copyImageAt(x, y)
+        label: 'Copy',
+        click: () => this.webContents.copy()
+      }))
+    }
+
+    if (canPaste && isEditable) {
+      items.push(new electron.MenuItem({
+        label: 'Paste',
+        click: () => this.webContents.paste()
       }))
     }
 
@@ -329,8 +342,10 @@ class ContextMenu {
       }))
     }
 
-    this.menu = electron.Menu.buildFromTemplate(items)
-    this.menu.popup()
+    if (items.length > 0) {
+      this.menu = electron.Menu.buildFromTemplate(items)
+      this.menu.popup()
+    }
   }
 
   close () {
@@ -394,12 +409,12 @@ class App {
         devtoolsBlurPolling = null
       })
 
-      wc.on('context-menu', (e, { x, y }) => {
+      wc.on('context-menu', (e, params) => {
         const ctrl = PearGUI.fromWebContents(wc)
         if (!ctrl) return
         if ((ctrl.view && ctrl.view.webContents === wc) || (ctrl.view === null && ctrl.win?.webContents === wc)) {
-          this.contextMenu = this.contextMenu || new ContextMenu(wc, { dev: this.ctx.devtools, x, y })
-          this.contextMenu.popup({ x, y })
+          this.contextMenu = this.contextMenu || new ContextMenu(wc, { dev: this.ctx.devtools })
+          this.contextMenu.popup(params)
         }
       })
       wc.on('render-process-gone', async (evt, details) => {


### PR DESCRIPTION
Changes from the last PR:

- Check `user-select` css prop to avoid copying elements with `user-select: none;`
- Fix paste behavior on buttons with a more strick check, line  (can't reproduce this bug, my test cases are much more modest than the entire Keet application, but I am confident that it's fixed)
- Fix the "Inspect Element" option, the bug was caused by a singleton state don't being updated, my fix was passing the state as a parameter