### PR TITLE
Pear.updates stage & release

### DIFF
--- a/test/04-updates.test.js
+++ b/test/04-updates.test.js
@@ -202,7 +202,134 @@ test('Pear.updates(listener) should notify when restaging and releasing applicat
 //   is(code, 0, 'exit code is 0')
 // })
 
-test('Pear.updates should notify Platform updates (different pear instances)', async function (t) {
+test('Pear.updates should notify Platform stage updates (different pear instances)', async function (t) {
+  const { ok, is, plan, timeout, comment, teardown } = t
+  plan(10)
+  timeout(180000)
+  teardown(async () => {
+    const shutdowner = new Helper({ platformDir })
+    await shutdowner.ready()
+    await shutdowner.shutdown()
+  }, { order: Infinity })
+
+  const localdev = path.join(os.cwd(), '..')
+  const osTmpDir = await fs.promises.realpath(os.tmpdir())
+  const tmpLocaldev = path.join(osTmpDir, 'tmp-localdev')
+  const platformDir = path.join(tmpLocaldev, 'pear')
+  const tmpPearDir = path.join(osTmpDir, 'tmp-pear')
+
+  const gc = async (dir) => await fs.promises.rm(dir, { recursive: true })
+
+  try { await gc(tmpLocaldev) } catch { }
+  try { await gc(tmpPearDir) } catch { }
+
+  teardown(async () => { await gc(tmpLocaldev) }, { order: Infinity })
+  teardown(async () => { await gc(tmpPearDir) }, { order: Infinity })
+
+  await fs.promises.mkdir(tmpLocaldev, { recursive: true })
+  await fs.promises.mkdir(tmpPearDir, { recursive: true })
+
+  comment('mirroring platform')
+  const srcDrive = new Localdrive(localdev)
+  const destDrive = new Localdrive(tmpLocaldev)
+  const mirror = srcDrive.mirror(destDrive, {
+    filter: (key) => {
+      return !key.startsWith('.git')
+    }
+  })
+  await mirror.done()
+  teardown(async () => { await srcDrive.close() })
+  teardown(async () => { await destDrive.close() })
+  const appStager = new Helper({ platformDir })
+  await appStager.ready()
+
+  const pid = Math.floor(Math.random() * 10000)
+  const fid = 'fixture'
+  const appDir = path.join(tmpLocaldev, 'test', 'fixtures', 'terminal')
+
+  comment('staging app')
+  const appStaging = appStager.stage({ id: Math.floor(Math.random() * 10000), channel: `test-${fid}`, name: `test-${fid}`, dir: appDir, dryRun: false, bare: true })
+  const appFinal = await Helper.pick(appStaging, { tag: 'final' })
+  ok(appFinal.success, 'stage succeeded')
+
+  comment('seeding app')
+  const appSeeder = new Helper({ platformDir })
+
+  await appSeeder.ready()
+  const appSeeding = appSeeder.seed({ id: Math.floor(Math.random() * 10000), channel: `test-${fid}`, name: `test-${fid}`, dir: appDir, key: null, clientArgv: [] })
+  const untilApp = await Helper.pick(appSeeding, [{ tag: 'key' }, { tag: 'announced' }])
+
+  const appKey = await untilApp.key
+  const appAnnounced = await untilApp.announced
+
+  ok(appKey, 'app key is ok')
+  ok(appAnnounced, 'seeding is announced')
+
+  comment('staging platform A')
+  const stager = new Helper({ platformDir })
+  await stager.ready()
+  const staging = stager.stage({ id: Math.floor(Math.random() * 10000), channel: `test-${pid}`, name: `test-${pid}`, dir: tmpLocaldev, dryRun: false, bare: true })
+  const final = await Helper.pick(staging, { tag: 'final' })
+  ok(final.success, 'stage succeeded')
+
+  comment('seeding platform A')
+  const seeder = new Helper({ platformDir })
+  await seeder.ready()
+  const seeding = seeder.seed({ id: Math.floor(Math.random() * 10000), channel: `test-${pid}`, name: `test-${pid}`, dir: tmpLocaldev, key: null, clientArgv: [] })
+  const until = await Helper.pick(seeding, [{ tag: 'key' }, { tag: 'announced' }])
+
+  const pearKey = await until.key
+  const announced = await until.announced
+
+  ok(pearKey, 'pear key is ok')
+  ok(announced, 'seeding is announced')
+
+  comment('bootstrapping platform B')
+  await Helper.bootstrap(pearKey, tmpPearDir)
+
+  comment('setting up trust preferences')
+  const prefs = 'preferences.json'
+  fs.writeFileSync(path.join(tmpPearDir, prefs), JSON.stringify({ trusted: [appKey] }))
+  teardown(() => { fs.unlinkSync(path.join(tmpPearDir, prefs)) }, { order: -Infinity })
+
+  comment('running app from platform B')
+  const currentDir = path.join(tmpPearDir, 'current')
+  const running = await Helper.open(appKey, { tags: ['exit'] }, { currentDir })
+  const { value } = await running.inspector.evaluate('Pear.versions()', { awaitPromise: true })
+  const { key: pearVersionKey, length: pearVersionLength } = value?.platform || {}
+  is(pearVersionKey, pearKey, 'platform version key matches staged key')
+
+  const updatePromise = await running.inspector.evaluate(`
+    __PEAR_TEST__.sub = Pear.updates()
+    new Promise((resolve) => __PEAR_TEST__.sub.once("data", resolve))
+  `, { returnByValue: false })
+  const updateActualPromise = running.inspector.awaitPromise(updatePromise.objectId)
+
+  const ts = () => new Date().toISOString().replace(/[:.]/g, '-')
+  const file = `${ts()}.tmp`
+  comment(`creating platform test file (${file})`)
+  fs.writeFileSync(path.join(tmpLocaldev, file), 'test')
+  teardown(() => { fs.unlinkSync(path.join(tmpLocaldev, file)) }, { order: -Infinity })
+
+  comment('restaging platform A')
+  const stager2 = new Helper({ platformDir })
+  await stager2.ready()
+  const staging2 = stager2.stage({ id: Math.floor(Math.random() * 10000), channel: `test-${pid}`, name: `test-${pid}`, dir: tmpLocaldev, dryRun: false, bare: true })
+  const final2 = await Helper.pick(staging2, { tag: 'final' })
+  ok(final2.success, 'stage succeeded')
+
+  const update = await updateActualPromise
+  const updateVersion = update?.value?.version
+  const pearUpdateLength = updateVersion.length
+  ok(pearUpdateLength > pearVersionLength, `platform version.length incremented (v${updateVersion?.fork}.${updateVersion?.length})`)
+
+  await running.inspector.evaluate('__PEAR_TEST__.sub.destroy()')
+  await running.inspector.close()
+  const { code } = await running.until.exit
+  is(code, 0, 'exit code is 0')
+})
+
+test('Pear.updates should notify Platform stage, Platform release updates (different pear instances)', async function (t) {
   const { ok, is, plan, timeout, comment, teardown } = t
   plan(12)
   timeout(180000)
@@ -351,7 +478,133 @@ test('Pear.updates should notify Platform updates (different pear instances)', a
   is(code, 0, 'exit code is 0')
 })
 
-test('Pear.updates should notify App updates (different pear instances)', async function (t) {
+test('Pear.updates should notify App stage updates (different pear instances)', async function (t) {
+  const { ok, is, plan, timeout, comment, teardown } = t
+  plan(10)
+  timeout(180000)
+  teardown(async () => {
+    const shutdowner = new Helper({ platformDir })
+    await shutdowner.ready()
+    await shutdowner.shutdown()
+  }, { order: Infinity })
+
+  const localdev = path.join(os.cwd(), '..')
+  const osTmpDir = await fs.promises.realpath(os.tmpdir())
+  const tmpLocaldev = path.join(osTmpDir, 'tmp-localdev')
+  const platformDir = path.join(tmpLocaldev, 'pear')
+  const tmpPearDir = path.join(osTmpDir, 'tmp-pear')
+
+  const gc = async (dir) => await fs.promises.rm(dir, { recursive: true })
+
+  try { await gc(tmpLocaldev) } catch { }
+  try { await gc(tmpPearDir) } catch { }
+
+  await fs.promises.mkdir(tmpLocaldev, { recursive: true })
+  await fs.promises.mkdir(tmpPearDir, { recursive: true })
+
+  teardown(async () => { await gc(tmpLocaldev) }, { order: Infinity })
+  teardown(async () => { await gc(tmpPearDir) }, { order: Infinity })
+
+  comment('mirroring platform')
+  const srcDrive = new Localdrive(localdev)
+  const destDrive = new Localdrive(tmpLocaldev)
+  const mirror = srcDrive.mirror(destDrive, {
+    filter: (key) => {
+      return !key.startsWith('.git')
+    }
+  })
+  await mirror.done()
+  teardown(async () => { srcDrive.close() })
+  teardown(async () => { destDrive.close() })
+
+  const appStager = new Helper({ platformDir })
+  await appStager.ready()
+  const pid = Math.floor(Math.random() * 10000)
+  const fid = 'fixture'
+  const appDir = path.join(tmpLocaldev, 'test', 'fixtures', 'terminal')
+
+  comment('staging app')
+  const appStaging = appStager.stage({ id: Math.floor(Math.random() * 10000), channel: `test-${fid}`, name: `test-${fid}`, dir: appDir, dryRun: false, bare: true })
+  const appFinal = await Helper.pick(appStaging, { tag: 'final' })
+  ok(appFinal.success, 'stage succeeded')
+
+  comment('seeding app')
+  const appSeeder = new Helper({ platformDir })
+  await appSeeder.ready()
+  const appSeeding = appSeeder.seed({ id: Math.floor(Math.random() * 10000), channel: `test-${fid}`, name: `test-${fid}`, dir: appDir, key: null, clientArgv: [] })
+  const untilApp = await Helper.pick(appSeeding, [{ tag: 'key' }, { tag: 'announced' }])
+
+  const appKey = await untilApp.key
+  const appAnnounced = await untilApp.announced
+
+  ok(appKey, 'app key is ok')
+  ok(appAnnounced, 'seeding is announced')
+
+  comment('staging platform A')
+  const stager = new Helper({ platformDir })
+  await stager.ready()
+  const staging = stager.stage({ id: Math.floor(Math.random() * 10000), channel: `test-${pid}`, name: `test-${pid}`, dir: tmpLocaldev, dryRun: false, bare: true })
+  const final = await Helper.pick(staging, { tag: 'final' })
+  ok(final.success, 'stage succeeded')
+
+  comment('seeding platform A')
+  const seeder = new Helper({ platformDir })
+  await seeder.ready()
+  const seeding = seeder.seed({ id: Math.floor(Math.random() * 10000), channel: `test-${pid}`, name: `test-${pid}`, dir: tmpLocaldev, key: null, clientArgv: [] })
+  const until = await Helper.pick(seeding, [{ tag: 'key' }, { tag: 'announced' }])
+
+  const pearKey = await until.key
+  const announced = await until.announced
+
+  ok(pearKey, 'pear key is ok')
+  ok(announced, 'seeding is announced')
+
+  comment('bootstrapping platform B')
+  await Helper.bootstrap(pearKey, tmpPearDir)
+
+  comment('setting up trust preferences')
+  const prefs = 'preferences.json'
+  fs.writeFileSync(path.join(tmpPearDir, prefs), JSON.stringify({ trusted: [appKey] }))
+  teardown(() => { fs.unlinkSync(path.join(tmpPearDir, prefs)) }, { order: -Infinity })
+
+  comment('running app from platform B')
+  const currentDir = path.join(tmpPearDir, 'current')
+  const running = await Helper.open(appKey, { tags: ['exit'] }, { currentDir })
+  const { value } = await running.inspector.evaluate('Pear.versions()', { awaitPromise: true })
+  const { key: appVersionKey, length: appVersionLength } = value?.app || {}
+  is(appVersionKey, appKey, 'app version key matches staged key')
+
+  const updatePromise = await running.inspector.evaluate(`
+    __PEAR_TEST__.sub = Pear.updates()
+    new Promise((resolve) => __PEAR_TEST__.sub.once("data", resolve))
+  `, { returnByValue: false })
+  const updateActualPromise = running.inspector.awaitPromise(updatePromise.objectId)
+
+  const ts = () => new Date().toISOString().replace(/[:.]/g, '-')
+  const file = `${ts()}.tmp`
+  comment(`creating app test file (${file})`)
+  fs.writeFileSync(path.join(appDir, file), 'test')
+  teardown(() => { fs.unlinkSync(path.join(appDir, file)) }, { order: -Infinity })
+
+  comment('restaging app')
+  const appStager2 = new Helper({ platformDir })
+  await appStager2.ready()
+  const appStaging2 = appStager2.stage({ id: Math.floor(Math.random() * 10000), channel: `test-${fid}`, name: `test-${fid}`, dir: appDir, dryRun: false, bare: true })
+  const appFinal2 = await Helper.pick(appStaging2, { tag: 'final' })
+  ok(appFinal2.success, 'stage succeeded')
+
+  const update = await updateActualPromise
+  const updateVersion = update?.value?.version
+  const appUpdateLength = updateVersion.length
+  ok(appUpdateLength > appVersionLength, `app version.length incremented (v${updateVersion?.fork}.${updateVersion?.length})`)
+
+  await running.inspector.evaluate('__PEAR_TEST__.sub.destroy()')
+  await running.inspector.close()
+  const { code } = await running.until.exit
+  is(code, 0, 'exit code is 0')
+})
+
+test('Pear.updates should notify App stage, App release updates (different pear instances)', async function (t) {
   const { ok, is, plan, timeout, comment, teardown } = t
   plan(12)
   timeout(180000)
@@ -463,7 +716,7 @@ test('Pear.updates should notify App updates (different pear instances)', async 
   teardown(() => { fs.unlinkSync(path.join(appDir, file)) }, { order: -Infinity })
 
   comment('restaging app')
-  const appStager2 = new Helper({ platformDir, logging: true })
+  const appStager2 = new Helper({ platformDir })
   await appStager2.ready()
   const appStaging2 = appStager2.stage({ id: Math.floor(Math.random() * 10000), channel: `test-${fid}`, name: `test-${fid}`, dir: appDir, dryRun: false, bare: true })
   const appFinal2 = await Helper.pick(appStaging2, { tag: 'final' })


### PR DESCRIPTION
This structures the `Pear.updates` tests as follows:
- app stage update
- app stage update, app release update
- plat stage update
- plat stage update, plat release update