### PR TITLE
added silent flag for detached run

### DIFF
--- a/cmd/run.js
+++ b/cmd/run.js
@@ -19,10 +19,10 @@ module.exports = (ipc) => async function run (args, devrun = false) {
   let askTrust = false
   try {
     const { json, dev, detached, store, 'ask-trust': ask, _ } = parse.args(args, {
-      boolean: ['json', 'dev', 'tmp-store', 'detached', 'ask-trust'],
+      boolean: ['json', 'dev', 'tmp-store', 'detached', 'ask-trust', 'silent'],
       string: ['store', 'link', 'checkout'],
       alias: { store: 's', 'tmp-store': 't' },
-      default: { json: false, dev: false, detached: false, 'ask-trust': true }
+      default: { json: false, dev: false, detached: false, 'ask-trust': true, silent: false }
     })
     askTrust = ask
     if (!_[0]) {

--- a/lib/run.js
+++ b/lib/run.js
@@ -25,9 +25,8 @@ module.exports = async function run ({ ipc, args, key, storage, detached, dir })
       const opts = { detached: true }
 
       if (!appling) {
-        args.unshift('run', '--detach')
-        const sp = spawn(constants.RUNTIME, args, opts)
-        setTimeout(() => sp.unref(), 1700)
+        args.unshift('run', '--detach', '--silent')
+        spawn(constants.RUNTIME, args, opts).unref()
         ipc.close().catch(console.error)
         return stream
       }
@@ -109,16 +108,20 @@ module.exports = async function run ({ ipc, args, key, storage, detached, dir })
         stream.destroy()
         ipc.close()
       })
-      child.stdout.on('data', (data) => { stream.push({ tag: 'stdout', data }) })
-      child.stderr.on('data', (data) => {
-        const str = data.toString()
-        const ignore = str.indexOf('DevTools listening on ws://') > -1 ||
-          str.indexOf('NSApplicationDelegate.applicationSupportsSecureRestorableState') > -1 ||
-          str.indexOf('devtools://devtools/bundled/panels/elements/elements.js') > -1 ||
-          str.indexOf('sysctlbyname for kern.hv_vmm_present failed with status -1') > -1
-        if (ignore) return
-        stream.push({ tag: 'stderr', data })
-      })
+
+      const silent = args.includes('--silent')
+      if (!silent) {
+        child.stdout.on('data', (data) => { stream.push({ tag: 'stdout', data }) })
+        child.stderr.on('data', (data) => {
+          const str = data.toString()
+          const ignore = str.indexOf('DevTools listening on ws://') > -1 ||
+                str.indexOf('NSApplicationDelegate.applicationSupportsSecureRestorableState') > -1 ||
+                str.indexOf('devtools://devtools/bundled/panels/elements/elements.js') > -1 ||
+                str.indexOf('sysctlbyname for kern.hv_vmm_present failed with status -1') > -1
+          if (ignore) return
+          stream.push({ tag: 'stderr', data })
+        })
+      }
     }
 
     return stream


### PR DESCRIPTION
This PR adds a --silent flag that fixes the detached process crashing due to the write the the std i/o of a parent process already ended.