### PR TITLE
Windows pipe name

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,6 +2,8 @@
 const HypercoreID = require('hypercore-id-encoding')
 const { platform, arch, isWindows, isLinux } = require('which-runtime')
 const { pathToFileURL, fileURLToPath } = require('url-file-url')
+const sodium = require('sodium-native')
+const b4a = require('b4a')
 
 const BIN = 'by-arch/' + platform + '-' + arch + '/bin/'
 
@@ -19,7 +21,10 @@ const IPC_ID = 'pear'
 const PLATFORM_URL = LOCALDEV ? new URL('pear/', swapURL) : new URL('../../../', swapURL)
 const PLATFORM_DIR = toPath(PLATFORM_URL)
 const PLATFORM_LOCK = toPath(new URL('corestores/platform/primary-key', PLATFORM_URL))
-const PIPE_ID = Buffer.from(PLATFORM_DIR).toString('hex').substring(0, 64)
+
+const buf = b4a.allocUnsafe(32)
+sodium.crypto_generichash(buf, b4a.from(PLATFORM_DIR))
+const PIPE_ID = b4a.toString(buf, 'hex')
 
 const DESKTOP_EXEC = isWindows
   ? 'pear-runtime-app/Pear Runtime.exe'

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,10 +21,7 @@ const IPC_ID = 'pear'
 const PLATFORM_URL = LOCALDEV ? new URL('pear/', swapURL) : new URL('../../../', swapURL)
 const PLATFORM_DIR = toPath(PLATFORM_URL)
 const PLATFORM_LOCK = toPath(new URL('corestores/platform/primary-key', PLATFORM_URL))
-
-const buf = b4a.allocUnsafe(32)
-sodium.crypto_generichash(buf, b4a.from(PLATFORM_DIR))
-const PIPE_ID = b4a.toString(buf, 'hex')
+const PIPE_ID = isWindows ? hashToHex(PLATFORM_DIR) : null
 
 const DESKTOP_EXEC = isWindows
   ? 'pear-runtime-app/Pear Runtime.exe'
@@ -91,4 +88,10 @@ function getKeys (z32) {
     z32,
     hex: HypercoreID.decode(z32).toString('hex')
   }
+}
+
+function hashToHex (s) {
+  const buf = b4a.allocUnsafe(32)
+  sodium.crypto_generichash(buf, b4a.from(s))
+  return b4a.toString(buf, 'hex')
 }

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -21,7 +21,6 @@ const IPC_ID = 'pear'
 const PLATFORM_URL = LOCALDEV ? new URL('pear/', swapURL) : new URL('../../../', swapURL)
 const PLATFORM_DIR = toPath(PLATFORM_URL)
 const PLATFORM_LOCK = toPath(new URL('corestores/platform/primary-key', PLATFORM_URL))
-const PIPE_ID = isWindows ? hashToHex(PLATFORM_DIR) : null
 
 const DESKTOP_EXEC = isWindows
   ? 'pear-runtime-app/Pear Runtime.exe'
@@ -61,7 +60,7 @@ exports.PLATFORM_CORESTORE = toPath(new URL('corestores/platform', PLATFORM_URL)
 exports.UPGRADE_LOCK = toPath(new URL('lock', PLATFORM_URL))
 exports.APPLINGS_PATH = toPath(new URL('applings', PLATFORM_URL))
 exports.MOUNT = mount.href.slice(0, -1)
-exports.SOCKET_PATH = isWindows ? `\\\\.\\pipe\\${IPC_ID}-${PIPE_ID}` : `${PLATFORM_DIR}/${IPC_ID}.sock`
+exports.SOCKET_PATH = isWindows ? `\\\\.\\pipe\\${IPC_ID}-${pipeId(PLATFORM_DIR)}` : `${PLATFORM_DIR}/${IPC_ID}.sock`
 exports.BOOT = require.main?.filename
 
 exports.CONNECT_TIMEOUT = 20_000
@@ -90,7 +89,7 @@ function getKeys (z32) {
   }
 }
 
-function hashToHex (s) {
+function pipeId (s) {
   const buf = b4a.allocUnsafe(32)
   sodium.crypto_generichash(buf, b4a.from(s))
   return b4a.toString(buf, 'hex')

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,6 +19,7 @@ const IPC_ID = 'pear'
 const PLATFORM_URL = LOCALDEV ? new URL('pear/', swapURL) : new URL('../../../', swapURL)
 const PLATFORM_DIR = toPath(PLATFORM_URL)
 const PLATFORM_LOCK = toPath(new URL('corestores/platform/primary-key', PLATFORM_URL))
+const PIPE_ID = PLATFORM_DIR.replace(/:/g, '').replace(/[/\\]/g, '-').toLowerCase()
 
 const DESKTOP_EXEC = isWindows
   ? 'pear-runtime-app/Pear Runtime.exe'
@@ -58,7 +59,7 @@ exports.PLATFORM_CORESTORE = toPath(new URL('corestores/platform', PLATFORM_URL)
 exports.UPGRADE_LOCK = toPath(new URL('lock', PLATFORM_URL))
 exports.APPLINGS_PATH = toPath(new URL('applings', PLATFORM_URL))
 exports.MOUNT = mount.href.slice(0, -1)
-exports.SOCKET_PATH = isWindows ? `\\\\.\\pipe\\${IPC_ID}` : `${PLATFORM_DIR}/${IPC_ID}.sock`
+exports.SOCKET_PATH = isWindows ? `\\\\.\\pipe\\${PIPE_ID}-${IPC_ID}` : `${PLATFORM_DIR}/${IPC_ID}.sock`
 exports.BOOT = require.main?.filename
 
 exports.CONNECT_TIMEOUT = 20_000

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,7 +19,7 @@ const IPC_ID = 'pear'
 const PLATFORM_URL = LOCALDEV ? new URL('pear/', swapURL) : new URL('../../../', swapURL)
 const PLATFORM_DIR = toPath(PLATFORM_URL)
 const PLATFORM_LOCK = toPath(new URL('corestores/platform/primary-key', PLATFORM_URL))
-const PIPE_ID = PLATFORM_DIR.replace(/:/g, '').replace(/[/\\]/g, '-').toLowerCase()
+const PIPE_ID = Buffer.from(PLATFORM_DIR).toString('hex').substring(0, 64)
 
 const DESKTOP_EXEC = isWindows
   ? 'pear-runtime-app/Pear Runtime.exe'
@@ -59,7 +59,7 @@ exports.PLATFORM_CORESTORE = toPath(new URL('corestores/platform', PLATFORM_URL)
 exports.UPGRADE_LOCK = toPath(new URL('lock', PLATFORM_URL))
 exports.APPLINGS_PATH = toPath(new URL('applings', PLATFORM_URL))
 exports.MOUNT = mount.href.slice(0, -1)
-exports.SOCKET_PATH = isWindows ? `\\\\.\\pipe\\${PIPE_ID}-${IPC_ID}` : `${PLATFORM_DIR}/${IPC_ID}.sock`
+exports.SOCKET_PATH = isWindows ? `\\\\.\\pipe\\${IPC_ID}-${PIPE_ID}` : `${PLATFORM_DIR}/${IPC_ID}.sock`
 exports.BOOT = require.main?.filename
 
 exports.CONNECT_TIMEOUT = 20_000

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "dependencies": {
     "@fontsource/open-sans": "^5.0.22",
     "@hyperswarm/seeders": "^1.1.6",
+    "b4a": "^1.6.6",
     "bare-bundle": "^1.0.0",
     "bare-env": "^2.1.0",
     "bare-events": "^2.2.0",

--- a/test/fixtures/terminal/index.js
+++ b/test/fixtures/terminal/index.js
@@ -1,8 +1,8 @@
 /* global Pear */
-const { teardown } = Pear
 import bareInspector from 'bare-inspector'
 import { Inspector } from 'pear-inspect'
 import Pipe from 'bare-pipe'
+const { teardown } = Pear
 
 const stdout = new Pipe(1)
 stdout.unref()
@@ -15,4 +15,4 @@ stdout.write(`{ "tag": "inspector", "data": { "key": "${inspectorKey}" }}`)
 
 global.__PEAR_TEST__ = { inspector, inspectorKey }
 
-teardown(async() => await inspector.disable())
+teardown(async () => await inspector.disable())

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,12 +19,12 @@ class Helper extends IPC {
   constructor (opts = {}) {
     const platformDir = opts.platformDir || PLATFORM_DIR
     const runtime = path.join(platformDir, '..', BY_ARCH)
-    const pipeId = platformDir.replace(/:/g, '').replace(/[/\\]/g, '-').toLowerCase()
+    const pipeId = Buffer.from(platformDir).toString('hex').substring(0, 64)
     const ipcId = 'pear'
 
     super({
       lock: path.join(platformDir, 'corestores', 'platform', 'primary-key'),
-      socketPath: isWindows ? `\\\\.\\pipe\\${pipeId}-${ipcId}` : `${platformDir}/${ipcId}.sock`,
+      socketPath: isWindows ? `\\\\.\\pipe\\${ipcId}-${pipeId}` : `${platformDir}/${ipcId}.sock`,
       connectTimeout: 20_000,
       connect: opts.expectSidecar
         ? true

--- a/test/helper.js
+++ b/test/helper.js
@@ -186,12 +186,6 @@ class Helper extends IPC {
     } catch { }
   }
 
-  hashToHex (s) {
-    const buf = b4a.allocUnsafe(32)
-    sodium.crypto_generichash(buf, b4a.from(s))
-    return b4a.toString(buf, 'hex')
-  }
-
   static Inspector = class extends ReadyResource {
     #session = null
 

--- a/test/helper.js
+++ b/test/helper.js
@@ -21,12 +21,16 @@ class Helper extends IPC {
   constructor (opts = {}) {
     const platformDir = opts.platformDir || PLATFORM_DIR
     const runtime = path.join(platformDir, '..', BY_ARCH)
-    const pipeId = isWindows ? hashToHex(platformDir) : null
     const ipcId = 'pear'
+    const pipeId = (s) => {
+      const buf = b4a.allocUnsafe(32)
+      sodium.crypto_generichash(buf, b4a.from(s))
+      return b4a.toString(buf, 'hex')
+    }
 
     super({
       lock: path.join(platformDir, 'corestores', 'platform', 'primary-key'),
-      socketPath: isWindows ? `\\\\.\\pipe\\${ipcId}-${pipeId}` : `${platformDir}/${ipcId}.sock`,
+      socketPath: isWindows ? `\\\\.\\pipe\\${ipcId}-${pipeId(platformDir)}` : `${platformDir}/${ipcId}.sock`,
       connectTimeout: 20_000,
       connect: opts.expectSidecar
         ? true

--- a/test/helper.js
+++ b/test/helper.js
@@ -19,10 +19,12 @@ class Helper extends IPC {
   constructor (opts = {}) {
     const platformDir = opts.platformDir || PLATFORM_DIR
     const runtime = path.join(platformDir, '..', BY_ARCH)
+    const pipeId = platformDir.replace(/:/g, '').replace(/[/\\]/g, '-').toLowerCase()
+    const ipcId = 'pear'
 
     super({
       lock: path.join(platformDir, 'corestores', 'platform', 'primary-key'),
-      socketPath: isWindows ? '\\\\.\\pipe\\pear' : `${platformDir}/pear.sock`,
+      socketPath: isWindows ? `\\\\.\\pipe\\${pipeId}-${ipcId}` : `${platformDir}/${ipcId}.sock`,
       connectTimeout: 20_000,
       connect: opts.expectSidecar
         ? true

--- a/test/package.json
+++ b/test/package.json
@@ -14,6 +14,7 @@
   "keywords": [],
   "author": "Holepunch",
   "dependencies": {
+    "b4a": "^1.6.6",
     "bare-fs": "^2.1.2",
     "bare-module": "^3.1.2",
     "bare-os": "^2.1.2",


### PR DESCRIPTION
Updates the pipe name on Windows by deriving it from the platform dir so that each platform dir is associated with a unique pipe. This aligns with our current mac/linux implementation, where different sockets are used for different platform instances.