### PR TITLE
bypass electron media access status in Linux and ask for media access in linux and windows

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1497,7 +1497,7 @@ class PearGUI extends ReadyResource {
 
   getMediaAccessStatus ({ mediaType }) {
     if (isLinux) {
-      return 'unknown'
+      return 'unsupported'
     } else {
       return electron.systemPreferences.getMediaAccessStatus(mediaType)
     }

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1496,11 +1496,15 @@ class PearGUI extends ReadyResource {
   }
 
   getMediaAccessStatus ({ mediaType }) {
-    return electron.systemPreferences.getMediaAccessStatus(mediaType)
+    if (isLinux) {
+      return 'unknown'
+    } else {
+      return electron.systemPreferences.getMediaAccessStatus(mediaType)
+    }
   }
 
   async askForMediaAccess (mediaType, client) {
-    if (mediaType === 'screen') return !!(await client.ctx.top.getMediaSourceId())
+    if (isLinux || isWindows) return false
     return electron.systemPreferences.askForMediaAccess(mediaType)
   }
 

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -42,7 +42,7 @@ module.exports = class PearGUI extends ReadyResource {
             camera: () => ipc.askForMediaAccess({ id, media: 'camera' }),
             screen: () => ipc.askForMediaAccess({ id, media: 'screen' })
           },
-          desktopSources: (options = null) => ipc.desktopSources(options)
+          desktopSources: (options = {}) => ipc.desktopSources(options)
         }
 
         const kGuiCtrl = Symbol('gui:ctrl')

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -42,7 +42,7 @@ module.exports = class PearGUI extends ReadyResource {
             camera: () => ipc.askForMediaAccess({ id, media: 'camera' }),
             screen: () => ipc.askForMediaAccess({ id, media: 'screen' })
           },
-          desktopSources: (options = null) => ipc.desktopSources(options = null)
+          desktopSources: (options = null) => ipc.desktopSources(options)
         }
 
         const kGuiCtrl = Symbol('gui:ctrl')


### PR DESCRIPTION
`getMediaAccessStatus` isn't supported by Electron on Linux.

- Mac: Allows programmatic access requests.
- Windows: Does not support programmatic access requests; must be done via the Windows user settings UI. However, it does allow checking the status.
- Linux: Lacks any standard for requesting or checking media access status.

The pull request also corrects a bug introduced in the line: `desktopSources: (options = null) => ipc.desktopSources(options = null)`

Bug introduced in commit https://github.com/holepunchto/pear/commit/2fcfad16b6092fe099b9df96ba3cf8db012464b7