### PR TITLE
Add support for Pear platform restarts in terminal apps

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -101,10 +101,8 @@ class API {
     if (this.#state.type === 'terminal' && !opts.platform) {
       Bare.exit(BARE_RESTART_EXIT_CODE)
     } else {
-      // TODO: remove default to hard when soft restarts for desktop apps lands
-      if (this.#state.type !== 'terminal' && opts.hard === undefined) opts.hard = true
       const restart = this.#reftrack(this.#ipc.restart(opts))
-      if (opts.platform && opts.hard) Bare.exit()
+      if (opts.platform && (opts.hard || opts.hard === undefined)) Bare.exit()
       return restart
     }
   }

--- a/lib/api.js
+++ b/lib/api.js
@@ -98,8 +98,13 @@ class API {
 
   restart = async (opts = {}) => {
     // TODO: use Pear.shutdown when it lands instead
-    if (this.#state.type === 'terminal' && !opts.platform) Bare.exit(BARE_RESTART_EXIT_CODE)
-    else return this.#reftrack(this.#ipc.restart(opts))
+    if (this.#state.type === 'terminal' && !opts.platform) {
+      Bare.exit(BARE_RESTART_EXIT_CODE)
+    } else {
+      const restart = this.#reftrack(this.#ipc.restart(opts))
+      if (opts.platform && opts.hard) Bare.exit()
+      return restart
+    }
   }
 
   updates = (listener) => this.messages({ type: 'pear/updates' }, listener)

--- a/lib/api.js
+++ b/lib/api.js
@@ -101,6 +101,8 @@ class API {
     if (this.#state.type === 'terminal' && !opts.platform) {
       Bare.exit(BARE_RESTART_EXIT_CODE)
     } else {
+      // TODO: remove default to hard when soft restarts for desktop apps lands
+      if (this.#state.type !== 'terminal' && opts.hard === undefined) opts.hard = true
       const restart = this.#reftrack(this.#ipc.restart(opts))
       if (opts.platform && opts.hard) Bare.exit()
       return restart

--- a/run/index.js
+++ b/run/index.js
@@ -114,17 +114,17 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
 
     const pear = new API(ipc, state)
 
-    pear.messages({ type: 'pear/restart' }, async () => {
+    global.Pear = pear
+
+    Pear.messages({ type: 'pear/restart' }, async () => {
       ipc.stream.destroy()
 
       const fd = await new Promise((resolve, reject) => fs.open(PLATFORM_LOCK, 'r+', (err, fd) => err ? reject(err) : resolve(fd)))
       await fsext.waitForLock(fd)
       await new Promise((resolve, reject) => fs.close(fd, (err) => err ? reject(err) : resolve(fd)))
 
-      await pear.restart()
+      await Pear.restart()
     })
-
-    global.Pear = pear
 
     const protocol = new Module.Protocol({
       exists (url) {

--- a/run/index.js
+++ b/run/index.js
@@ -34,6 +34,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
   }
 
   let cwd = os.cwd()
+  const originalCwd = cwd
   let dir = cwd
   let base = null
   if (key === null) {
@@ -43,8 +44,8 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
     base = project(dir, pathname, cwd)
     dir = base.dir
     if (dir !== cwd) {
-      Bare.on('exit', () => os.chdir(cwd)) // TODO: remove this once Pear.shutdown is used to close
-      teardown(() => os.chdir(cwd))
+      Bare.on('exit', () => os.chdir(originalCwd)) // TODO: remove this once Pear.shutdown is used to close
+      teardown(() => os.chdir(originalCwd))
       os.chdir(dir)
       cwd = dir
     }

--- a/run/index.js
+++ b/run/index.js
@@ -117,7 +117,8 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
 
     global.Pear = pear
 
-    global.Pear.messages({ type: 'pear/reload' }, async () => {
+    const reloadSubscriber = ipc.messages({ type: 'pear/reload' })
+    reloadSubscriber.on('data', async () => {
       ipc.stream.destroy()
 
       const fd = await new Promise((resolve, reject) => fs.open(PLATFORM_LOCK, 'r+', (err, fd) => err ? reject(err) : resolve(fd)))

--- a/run/index.js
+++ b/run/index.js
@@ -124,7 +124,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
       await fsext.waitForLock(fd)
       await new Promise((resolve, reject) => fs.close(fd, (err) => err ? reject(err) : resolve(fd)))
 
-      await Pear.restart()
+      await global.Pear.restart()
     })
 
     const protocol = new Module.Protocol({

--- a/run/index.js
+++ b/run/index.js
@@ -117,7 +117,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
     global.Pear = pear
 
     /* global Pear */
-    Pear.messages({ type: 'pear/restart' }, async () => {
+    Pear.messages({ type: 'pear/reload' }, async () => {
       ipc.stream.destroy()
 
       const fd = await new Promise((resolve, reject) => fs.open(PLATFORM_LOCK, 'r+', (err, fd) => err ? reject(err) : resolve(fd)))

--- a/run/index.js
+++ b/run/index.js
@@ -102,7 +102,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
   if (type === 'terminal') {
     const state = new State({ flags, link, dir, cmdArgs, cwd })
 
-    state.update({ host, id })
+    state.update({ host, id, type })
 
     if (state.error) {
       console.error(state.error)

--- a/run/index.js
+++ b/run/index.js
@@ -116,6 +116,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
 
     global.Pear = pear
 
+    /* global Pear */
     Pear.messages({ type: 'pear/restart' }, async () => {
       ipc.stream.destroy()
 

--- a/run/index.js
+++ b/run/index.js
@@ -117,8 +117,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
 
     global.Pear = pear
 
-    /* global Pear */
-    Pear.messages({ type: 'pear/reload' }, async () => {
+    global.Pear.messages({ type: 'pear/reload' }, async () => {
       ipc.stream.destroy()
 
       const fd = await new Promise((resolve, reject) => fs.open(PLATFORM_LOCK, 'r+', (err, fd) => err ? reject(err) : resolve(fd)))

--- a/run/index.js
+++ b/run/index.js
@@ -121,7 +121,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
       await fsext.waitForLock(fd)
       await new Promise((resolve, reject) => fs.close(fd, (err) => err ? reject(err) : resolve(fd)))
 
-      await Pear.restart()
+      await pear.restart()
     })
 
     global.Pear = pear

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -552,7 +552,6 @@ class Sidecar extends ReadyResource {
       await new Promise(resolve => setTimeout(resolve, 1500))
     }
 
-
     const sidecarClosed = new Promise((resolve) => this.corestore.once('close', resolve))
     const restarts = (await this.#shutdown(client))
       .filter(({ run, options }) => run && (options?.type !== 'terminal' || hard))

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -539,12 +539,15 @@ class Sidecar extends ReadyResource {
     }
 
     const sidecarClosed = new Promise((resolve) => this.corestore.once('close', resolve))
-    const restarts = (await this.#shutdown(client))
-      .filter(({ run, options }) => run && (options?.type !== 'terminal' || hard))
+    let restarts = await this.#shutdown(client)
     // ample time for any OS cleanup operations:
     await new Promise((resolve) => setTimeout(resolve, 1500))
     // shutdown successful, reset death clock
     this.deathClock()
+
+    if (!hard) return
+
+    restarts = restarts.filter(({ run }) => run)
     if (restarts.length === 0) return
     if (this.verbose) console.log('Restarting', restarts.length, 'apps')
 

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -472,10 +472,10 @@ class Sidecar extends ReadyResource {
 
   shutdown (params, client) { return this.#shutdown(client) }
 
-  get closeableClients () {
+  get uniqueClients () {
     if (this.hasClients === false) return []
 
-    const closeableClients = []
+    const uniqueClients = []
     const seen = new Set()
     for (const client of this.clients) {
       const app = client.userData
@@ -483,15 +483,15 @@ class Sidecar extends ReadyResource {
       if (seen.has(app.state.id)) continue
       seen.add(app.state.id)
 
-      closeableClients.push(client)
+      uniqueClients.push(client)
     }
 
-    return closeableClients
+    return uniqueClients
   }
 
   closeClients () {
     const metadata = []
-    for (const client of this.closeableClients) {
+    for (const client of this.uniqueClients) {
       const app = client.userData
 
       const { pid, cmdArgs, cwd, dir, runtime, appling, env, run, options } = app.state
@@ -543,7 +543,7 @@ class Sidecar extends ReadyResource {
     }
 
     if (!hard) {
-      const clients = this.closeableClients.filter(c => c?.userData?.state?.options?.type === 'terminal')
+      const clients = this.uniqueClients.filter(c => c?.userData?.state?.options?.type === 'terminal')
       if (this.verbose) console.log(`Soft-restarting ${clients.length} terminal app(s)`)
       for (const client of clients) client.userData.message({ type: 'pear/restart' })
 

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -532,7 +532,7 @@ class Sidecar extends ReadyResource {
     if (!hard && this.hasClients) {
       const seen = new Set()
       for (const { userData: app } of this.client) {
-        if (!app.state || seen.has(app.state.id)) return
+        if (!app.state || seen.has(app.state.id)) continue
         seen.add(app.state.id)
         app.message({ type: 'pear/reload' })
       }

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -531,7 +531,7 @@ class Sidecar extends ReadyResource {
 
     if (!hard && this.hasClients) {
       const seen = new Set()
-      for (const { userData: app } of this.client) {
+      for (const { userData: app } of this.clients) {
         if (!app.state || seen.has(app.state.id)) continue
         seen.add(app.state.id)
         app.message({ type: 'pear/reload' })

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -543,9 +543,9 @@ class Sidecar extends ReadyResource {
     }
 
     if (!hard) {
-      for (const client of this.closeableClients.filter(c => c?.userData?.state?.options?.type === 'terminal')) {
-        client.userData.message({ type: 'pear/restart' })
-      }
+      const clients = this.closeableClients.filter(c => c?.userData?.state?.options?.type === 'terminal')
+      if (this.verbose) console.log(`Soft-restarting ${clients.length} terminal app(s)`)
+      for (const client of clients) client.userData.message({ type: 'pear/restart' })
 
       // Wait for 'pear/restart' messages to send and get handled by clients
       // TODO: Figure out how to cleanly flush this buffer

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -489,7 +489,7 @@ class Sidecar extends ReadyResource {
     return metadata
   }
 
-  async restart ({ platform = false, hard = false } = {}, client) {
+  async restart ({ platform = false, hard = true } = {}, client) {
     if (this.verbose) console.log(`${hard ? 'Hard' : 'Soft'} restarting ${platform ? 'platform' : 'client'}`)
     if (platform === false) {
       const { dir, cwd, cmdArgs, env } = client.userData.state

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -531,11 +531,11 @@ class Sidecar extends ReadyResource {
 
     if (!hard && this.hasClients) {
       const seen = new Set()
-      this.clients.filter(({ userData: app }) => {
-        if (seen.has(app.state.id)) return false
+      for (const { userData: app } of this.client) {
+        if (!app.state || seen.has(app.state.id)) return
         seen.add(app.state.id)
-        return app.state && app?.state?.options?.type === 'terminal'
-      }).forEach(client => client.userData.message({ type: 'pear/reload' }))
+        if (app?.state?.options?.type === 'terminal') app.message({ type: 'pear/reload' })
+      }
     }
 
     const sidecarClosed = new Promise((resolve) => this.corestore.once('close', resolve))

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -542,6 +542,17 @@ class Sidecar extends ReadyResource {
       return
     }
 
+    if (!hard) {
+      for (const client of this.closeableClients.filter(c => c?.userData?.state?.options?.type === 'terminal')) {
+        client.userData.message({ type: 'pear/restart' })
+      }
+
+      // Wait for 'pear/restart' messages to send and get handled by clients
+      // TODO: Figure out how to cleanly flush this buffer
+      await new Promise(resolve => setTimeout(resolve, 1500))
+    }
+
+
     const sidecarClosed = new Promise((resolve) => this.corestore.once('close', resolve))
     const restarts = (await this.#shutdown(client))
       .filter(({ run, options }) => run && (options?.type !== 'terminal' || hard))

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -472,15 +472,28 @@ class Sidecar extends ReadyResource {
 
   shutdown (params, client) { return this.#shutdown(client) }
 
-  closeClients () {
+  get closeableClients () {
     if (this.hasClients === false) return []
-    const metadata = []
+
+    const closeableClients = []
     const seen = new Set()
     for (const client of this.clients) {
       const app = client.userData
       if (!app || !app.state) continue // ignore e.g. `pear sidecar` cli i/o client
       if (seen.has(app.state.id)) continue
       seen.add(app.state.id)
+
+      closeableClients.push(client)
+    }
+
+    return closeableClients
+  }
+
+  closeClients () {
+    const metadata = []
+    for (const client of this.closeableClients) {
+      const app = client.userData
+
       const { pid, cmdArgs, cwd, dir, runtime, appling, env, run } = app.state
       metadata.push({ pid, cmdArgs, cwd, dir, runtime, appling, env, run })
       const tearingDown = app.teardown()

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -550,7 +550,6 @@ class Sidecar extends ReadyResource {
 
     await sidecarClosed
 
-    const TERMINAL_RUNTIME = RUNTIME
     for (const { cwd, dir, appling, cmdArgs, env, options } of restarts) {
       const opts = { cwd, env, detached: true, stdio: 'ignore' }
       if (appling) {
@@ -558,9 +557,9 @@ class Sidecar extends ReadyResource {
         if (isMac) spawn('open', [applingPath.split('.app')[0] + '.app'], opts).unref()
         else spawn(applingPath, opts).unref()
       } else {
-        const RUNTIME = this.updater === null
-          ? (options?.type === 'terminal' ? TERMINAL_RUNTIME : DESKTOP_RUNTIME)
-          : this.updater.swap + (options?.type === 'terminal' ? TERMINAL_RUNTIME : DESKTOP_RUNTIME).slice(SWAP.length)
+        const TARGET_RUNTIME = this.updater === null
+          ? (options?.type === 'terminal' ? RUNTIME : DESKTOP_RUNTIME)
+          : this.updater.swap + (options?.type === 'terminal' ? RUNTIME : DESKTOP_RUNTIME).slice(SWAP.length)
 
         const cmd = command('run', ...runDefinition)
         cmd.parse(cmdArgs.slice(1))
@@ -573,7 +572,7 @@ class Sidecar extends ReadyResource {
           cmdArgs.push(dir)
         }
 
-        spawn(RUNTIME, cmdArgs, opts).unref()
+        spawn(TARGET_RUNTIME, cmdArgs, opts).unref()
       }
     }
   }

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -490,7 +490,7 @@ class Sidecar extends ReadyResource {
   }
 
   async restart ({ platform = false, hard = false } = {}, client) {
-    if (this.verbose) console.log('Restarting ' + (platform ? 'platform' : 'client'))
+    if (this.verbose) console.log(`${hard ? 'Hard' : 'Soft'} restarting ${platform ? 'platform' : 'client'}`)
     if (platform === false) {
       const { dir, cwd, cmdArgs, env } = client.userData.state
       const appling = client.userData.state.appling

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -572,8 +572,8 @@ class Sidecar extends ReadyResource {
         if (isMac) spawn('open', [applingPath.split('.app')[0] + '.app'], opts).unref()
         else spawn(applingPath, opts).unref()
       } else {
-        const baseRuntime = options?.type === 'terminal' ? RUNTIME: DESKTOP_RUNTIME
-        const RUNTIME = this.updater === null ? baseRuntime : this.updater.swap + baseRuntime.slice(SWAP.length)
+        const baseRuntime = options?.type === 'terminal' ? RUNTIME : DESKTOP_RUNTIME
+        const runtime = this.updater === null ? baseRuntime : this.updater.swap + baseRuntime.slice(SWAP.length)
 
         const cmd = command('run', ...runDefinition)
         cmd.parse(cmdArgs.slice(1))
@@ -586,7 +586,7 @@ class Sidecar extends ReadyResource {
           cmdArgs.push(dir)
         }
 
-        spawn(RUNTIME, cmdArgs, opts).unref()
+        spawn(runtime, cmdArgs, opts).unref()
       }
     }
   }

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -546,10 +546,6 @@ class Sidecar extends ReadyResource {
       const clients = this.uniqueClients.filter(c => c?.userData?.state?.options?.type === 'terminal')
       if (this.verbose) console.log(`Soft-restarting ${clients.length} terminal app(s)`)
       for (const client of clients) client.userData.message({ type: 'pear/restart' })
-
-      // Wait for 'pear/restart' messages to send and get handled by clients
-      // TODO: Figure out how to cleanly flush this buffer
-      await new Promise(resolve => setTimeout(resolve, 1500))
     }
 
     const sidecarClosed = new Promise((resolve) => this.corestore.once('close', resolve))

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -564,6 +564,7 @@ class Sidecar extends ReadyResource {
 
     await sidecarClosed
 
+    const TERMINAL_RUNTIME = RUNTIME
     for (const { cwd, dir, appling, cmdArgs, env, options } of restarts) {
       const opts = { cwd, env, detached: true, stdio: 'ignore' }
       if (appling) {
@@ -571,8 +572,9 @@ class Sidecar extends ReadyResource {
         if (isMac) spawn('open', [applingPath.split('.app')[0] + '.app'], opts).unref()
         else spawn(applingPath, opts).unref()
       } else {
-        const baseRuntime = options?.type === 'terminal' ? RUNTIME : DESKTOP_RUNTIME
-        const runtime = this.updater === null ? baseRuntime : this.updater.swap + baseRuntime.slice(SWAP.length)
+        const RUNTIME = this.updater === null
+          ? (options?.type === 'terminal' ? TERMINAL_RUNTIME : DESKTOP_RUNTIME)
+          : this.updater.swap + (options?.type === 'terminal' ? TERMINAL_RUNTIME : DESKTOP_RUNTIME).slice(SWAP.length)
 
         const cmd = command('run', ...runDefinition)
         cmd.parse(cmdArgs.slice(1))
@@ -585,7 +587,7 @@ class Sidecar extends ReadyResource {
           cmdArgs.push(dir)
         }
 
-        spawn(runtime, cmdArgs, opts).unref()
+        spawn(RUNTIME, cmdArgs, opts).unref()
       }
     }
   }

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -545,7 +545,7 @@ class Sidecar extends ReadyResource {
       if (this.verbose && terminalClients.length > 0) {
         console.log(`Soft-restarting ${terminalClients.length} terminal app(s)`)
       }
-      for (const client of terminalClients) client.userData.message({ type: 'pear/restart' })
+      for (const client of terminalClients) client.userData.message({ type: '' })
     }
 
     const sidecarClosed = new Promise((resolve) => this.corestore.once('close', resolve))

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -534,7 +534,7 @@ class Sidecar extends ReadyResource {
       for (const { userData: app } of this.client) {
         if (!app.state || seen.has(app.state.id)) return
         seen.add(app.state.id)
-        if (app?.state?.options?.type === 'terminal') app.message({ type: 'pear/reload' })
+        app.message({ type: 'pear/reload' })
       }
     }
 

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -494,8 +494,8 @@ class Sidecar extends ReadyResource {
     for (const client of this.closeableClients) {
       const app = client.userData
 
-      const { pid, cmdArgs, cwd, dir, runtime, appling, env, run } = app.state
-      metadata.push({ pid, cmdArgs, cwd, dir, runtime, appling, env, run })
+      const { pid, cmdArgs, cwd, dir, runtime, appling, env, run, options } = app.state
+      metadata.push({ pid, cmdArgs, cwd, dir, runtime, appling, env, run, options })
       const tearingDown = app.teardown()
       if (tearingDown === false) client.close()
     }


### PR DESCRIPTION
Adds support for:
- `Pear.restart({ platform: true })` which tells the terminal app to restart in-place (soft restart)
- `Pear.restart({ platform: true, hard: true })` which completely relaunches terminal apps through sidecar instead restarting in-place