### PR TITLE
Add HTTP/HTTPS hostname whitelisting for Pear desktop apps

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -13,8 +13,6 @@ const constants = require('../constants')
 const kMap = Symbol('pear.gui.map')
 const kCtrl = Symbol('pear.gui.ctrl')
 
-const HTTP_PREFIX_MATCHER = /https?:\/\//i
-
 class Menu {
   static PEAR = 0
   static APP = 0
@@ -1060,8 +1058,8 @@ class Window extends GuiCtrl {
     if (interload && (await interload(this)) === false) return false
 
     const allowedHosts = Object.values(this?.state?.config?.options?.links || {})
-      .filter(link => HTTP_PREFIX_MATCHER.test(link))
-      .map(link => new URL(link)) ?? []
+      .map(link => new URL(link))
+      .filter(link => link.protocol === 'http:' || link.protocol === 'https:') ?? []
     allowedHosts.push(new URL(this.entry))
 
     const requestFilter = (request) => {

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1062,15 +1062,15 @@ class Window extends GuiCtrl {
       .filter((link) => link.protocol === 'http:' || link.protocol === 'https:') ?? []
     allowedHosts.push(new URL(this.entry))
 
-    const requestFilter = (request) => {
-      const url = new URL(request.url)
-      return allowedHosts.find((link) => link.host === url.host && link.protocol === url.protocol)
-        ? electron.net.fetch(request, { bypassCustomProtocolHandlers: true })
-        : new Response(null, { status: 403 })
+    const requestFilter = (details, callback) => {
+      const url = new URL(details.url)
+      const result = { cancel: !allowedHosts.find((link) => link.host === url.host && link.protocol === url.protocol) }
+      callback(result)
     }
 
-    session.protocol.handle('https', requestFilter)
-    session.protocol.handle('http', requestFilter)
+    const urls = ['http://*/*', 'https://*/*']
+    this.session.webRequest.onBeforeRequest({ urls }, requestFilter)
+    session.webRequest.onBeforeRequest({ urls }, requestFilter)
 
     if (this.closing) return false
 

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -986,17 +986,6 @@ class Window extends GuiCtrl {
     const session = electron.session.fromPartition(`persist:${this.sessname || this.state.key?.z32 || this.state.dir}`)
     session.setUserAgent(ua)
 
-    const allowedHosts = [new URL(this.entry).host, ...(this?.state?.manifest?.pear?.allowedHosts ?? [])]
-    const requestFilter = (request) => {
-      const requestUrl = new URL(request.url)
-      return allowedHosts.includes(requestUrl.host)
-        ? electron.net.fetch(request, { bypassCustomProtocolHandlers: true })
-        : Object.assign(new Response(null, { status: 403 }))
-    }
-
-    session.protocol.handle('https', requestFilter)
-    session.protocol.handle('http', requestFilter)
-
     const { show = true } = { show: (options.show || options.window?.show) }
     const { height = this.constructor.height, width = this.constructor.width } = options
     this.win = new BrowserWindow({
@@ -1067,6 +1056,17 @@ class Window extends GuiCtrl {
     const decalLoading = this.win.loadURL(decalUrl)
 
     if (interload && (await interload(this)) === false) return false
+
+    const allowedHosts = [new URL(this.entry).host, ...(this?.state?.config?.options?.allowedHosts ?? [])]
+    const requestFilter = (request) => {
+      const requestUrl = new URL(request.url)
+      return allowedHosts.includes(requestUrl.host)
+        ? electron.net.fetch(request, { bypassCustomProtocolHandlers: true })
+        : Object.assign(new Response(null, { status: 403 }))
+    }
+
+    session.protocol.handle('https', requestFilter)
+    session.protocol.handle('http', requestFilter)
 
     if (this.closing) return false
 

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1058,13 +1058,13 @@ class Window extends GuiCtrl {
     if (interload && (await interload(this)) === false) return false
 
     const allowedHosts = Object.values(this?.state?.config?.options?.links || {})
-      .map(link => new URL(link))
-      .filter(link => link.protocol === 'http:' || link.protocol === 'https:') ?? []
+      .map((link) => new URL(link))
+      .filter((link) => link.protocol === 'http:' || link.protocol === 'https:') ?? []
     allowedHosts.push(new URL(this.entry))
 
     const requestFilter = (request) => {
       const url = new URL(request.url)
-      return allowedHosts.find(link => link.host === url.host && link.protocol === url.protocol)
+      return allowedHosts.find((link) => link.host === url.host && link.protocol === url.protocol)
         ? electron.net.fetch(request, { bypassCustomProtocolHandlers: true })
         : new Response(null, { status: 403 })
     }

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1057,7 +1057,7 @@ class Window extends GuiCtrl {
 
     if (interload && (await interload(this)) === false) return false
 
-    const allowedHosts = Object.values(this?.state?.config?.options?.links || {})
+    const allowedHosts = Array.from(new Set(Object.values(this?.state?.config?.options?.links || {})))
       .map((link) => new URL(link))
       .filter((link) => link.protocol === 'http:' || link.protocol === 'https:') ?? []
     allowedHosts.push(new URL(this.entry))

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1062,7 +1062,7 @@ class Window extends GuiCtrl {
       const requestUrl = new URL(request.url)
       return allowedHosts.includes(requestUrl.host)
         ? electron.net.fetch(request, { bypassCustomProtocolHandlers: true })
-        : Object.assign(new Response(null, { status: 403 }))
+        : new Response(null, { status: 403 })
     }
 
     session.protocol.handle('https', requestFilter)

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -443,6 +443,7 @@ class Sidecar extends ReadyResource {
     }
     if (typeof pkg?.pear?.links === 'object' && pkg.pear.links !== null) {
       for (const link of Object.values(pkg.pear.links)) {
+        if (link.slice(0, 7).toLowerCase() !== 'pear://') continue
         try {
           trusted.add(hypercoreid.encode(hypercoreid.decode(link)))
         } catch {

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -443,7 +443,7 @@ class Sidecar extends ReadyResource {
     }
     if (typeof pkg?.pear?.links === 'object' && pkg.pear.links !== null) {
       for (const link of Object.values(pkg.pear.links)) {
-        if (link.slice(0, 7).toLowerCase() !== 'pear://') continue
+        if (new URL(link).protocol !== 'pear:') continue
         try {
           trusted.add(hypercoreid.encode(hypercoreid.decode(link)))
         } catch {

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -443,7 +443,7 @@ class Sidecar extends ReadyResource {
     }
     if (typeof pkg?.pear?.links === 'object' && pkg.pear.links !== null) {
       for (const link of Object.values(pkg.pear.links)) {
-        if (new URL(link).protocol !== 'pear:') continue
+        if (!parseLink(link).key) continue
         try {
           trusted.add(hypercoreid.encode(hypercoreid.decode(link)))
         } catch {


### PR DESCRIPTION
Allows only requests to the sidecar host (127.0.0.1:9342) by default and returns 404 for all other requests. Additional hosts can be whitelisted by listing them as values in the pear.links object in package.json 

Example: adding `{ google: 'https://google.com' }` in `pear.links` will allow all requests to google.com (HTTPS) and all its subpaths (google.com/test etc.)

