### PR TITLE
Use hostname without port number when checking for HTTP whitelist

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1064,8 +1064,8 @@ class Window extends GuiCtrl {
 
     const requestFilter = (details, respond) => {
       const url = new URL(details.url)
-      const isAllowed = allowedHosts.some((link) =>
-        (link.port === '' ? link.hostname === url.hostname : link.host === url.host) && link.protocol === url.protocol)
+      const isAllowed = allowedHosts.some(({ protocol, hostname, port }) =>
+        protocol === url.protocol && hostname === url.hostname && (port === '' || port === url.port))
       respond({ cancel: isAllowed === false })
     }
 

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1064,7 +1064,11 @@ class Window extends GuiCtrl {
 
     const requestFilter = (details, callback) => {
       const url = new URL(details.url)
-      const result = { cancel: !allowedHosts.find((link) => link.hostname === url.hostname && link.protocol === url.protocol) }
+      const result = {
+        cancel: !allowedHosts.find((link) =>
+          (link.host.split(':').length > 1 ? link.host === url.host : link.hostname === url.hostname) &&
+          link.protocol === url.protocol)
+      }
       callback(result)
     }
 

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1062,14 +1062,11 @@ class Window extends GuiCtrl {
       .filter((link) => link.protocol === 'http:' || link.protocol === 'https:') ?? []
     allowedHosts.push(new URL(this.entry))
 
-    const requestFilter = (details, callback) => {
+    const requestFilter = (details, respond) => {
       const url = new URL(details.url)
-      const result = {
-        cancel: !allowedHosts.find((link) =>
-          (link.host.split(':').length > 1 ? link.host === url.host : link.hostname === url.hostname) &&
-          link.protocol === url.protocol)
-      }
-      callback(result)
+      const isAllowed = allowedHosts.some((link) =>
+        (link.port === '' ? link.hostname === url.hostname : link.host === url.host) && link.protocol === url.protocol)
+      respond({ cancel: isAllowed === false })
     }
 
     const urls = ['http://*/*', 'https://*/*']

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1064,7 +1064,7 @@ class Window extends GuiCtrl {
 
     const requestFilter = (details, callback) => {
       const url = new URL(details.url)
-      const result = { cancel: !allowedHosts.find((link) => link.host === url.host && link.protocol === url.protocol) }
+      const result = { cancel: !allowedHosts.find((link) => link.hostname === url.hostname && link.protocol === url.protocol) }
       callback(result)
     }
 


### PR DESCRIPTION
Switches to `new URL().hostname` instead of `new URL().host` as it does not include the port