### PR TITLE
Bugfix: add err handler sync when streaming bundle

### DIFF
--- a/subsystems/sidecar/lib/bundle.js
+++ b/subsystems/sidecar/lib/bundle.js
@@ -172,7 +172,7 @@ module.exports = class Bundle {
     const entry = await this.entry(key)
     const result = await this.drive.get(entry)
     if (this.trace && result !== null) {
-      if (entry.value.blob) await this.trace.capture([entry.value.blob.blockLength, entry.value.blob.blockOffset])
+      if (entry.value.blob) this.trace.capture([entry.value.blob.blockLength, entry.value.blob.blockOffset])
     }
     return result
   }
@@ -186,15 +186,8 @@ module.exports = class Bundle {
     return await this.drive.del(key)
   }
 
-  async getMeta (key) {
-    const meta = await this.entry(key)
-    if (meta === null) return null
-    if (this.trace && meta.value.blob) await this.trace.capture([meta.value.blob.blockLength, meta.value.blob.blockOffset])
-    return meta
-  }
-
-  // call getMeta first if you have a key
   streamFrom (meta) {
+    if (this.trace && meta.value.blob) this.trace.capture([meta.value.blob.blockLength, meta.value.blob.blockOffset])
     const stream = this.drive.createReadStream(meta)
     return stream
   }

--- a/subsystems/sidecar/lib/bundle.js
+++ b/subsystems/sidecar/lib/bundle.js
@@ -186,11 +186,16 @@ module.exports = class Bundle {
     return await this.drive.del(key)
   }
 
-  async streamFrom (key) {
+  async getMeta (key) {
     const meta = await this.entry(key)
     if (meta === null) return null
-    const stream = this.drive.createReadStream(meta)
     if (this.trace && meta.value.blob) await this.trace.capture([meta.value.blob.blockLength, meta.value.blob.blockOffset])
+    return meta
+  }
+
+  // call getMeta first if you have a key
+  streamFrom (meta) {
+    const stream = this.drive.createReadStream(meta)
     return stream
   }
 

--- a/subsystems/sidecar/lib/http.js
+++ b/subsystems/sidecar/lib/http.js
@@ -165,8 +165,10 @@ module.exports = class Http extends ReadyResource {
         app.warmup({ protocol, batch })
       }
 
-      const meta = await bundle.getMeta(link.filename)
-      const stream = meta === null ? null : bundle.streamFrom(meta)
+      const meta = await this.entry(link.filename)
+      if (meta === null) return
+
+      const stream = bundle.streamFrom(meta)
       await streamx.pipelinePromise(stream, res)
     }
   }

--- a/subsystems/sidecar/lib/http.js
+++ b/subsystems/sidecar/lib/http.js
@@ -164,7 +164,9 @@ module.exports = class Http extends ReadyResource {
         }
         app.warmup({ protocol, batch })
       }
-      const stream = await bundle.streamFrom(link.filename)
+
+      const meta = await bundle.getMeta(link.filename)
+      const stream = meta === null ? null : bundle.streamFrom(meta)
       await streamx.pipelinePromise(stream, res)
     }
   }

--- a/subsystems/sidecar/lib/tracer.js
+++ b/subsystems/sidecar/lib/tracer.js
@@ -48,7 +48,7 @@ module.exports = class Tracer extends Readable {
     return (seq) => this.capture(seq, this.constructor.META)
   }
 
-  async capture (seq, core = this.constructor.DATA) {
+  capture (seq, core = this.constructor.DATA) {
     if (Array.isArray(seq)) {
       const [blockLength, blockOffset] = seq
       for (let i = 0; i < blockLength; i++) this.capture(i + blockOffset)


### PR DESCRIPTION
Previous behaviour could throw an unhandled exception if the stream threw between creation and its being used in `pipelinePromise`.
Current behaviour first gets the metadata (which is async) and then creates the stream sync.
