### PR TITLE
Revert "Bugfix: add err handler sync when streaming bundle"

### DIFF
--- a/subsystems/sidecar/lib/bundle.js
+++ b/subsystems/sidecar/lib/bundle.js
@@ -172,7 +172,7 @@ module.exports = class Bundle {
     const entry = await this.entry(key)
     const result = await this.drive.get(entry)
     if (this.trace && result !== null) {
-      if (entry.value.blob) this.trace.capture([entry.value.blob.blockLength, entry.value.blob.blockOffset])
+      if (entry.value.blob) await this.trace.capture([entry.value.blob.blockLength, entry.value.blob.blockOffset])
     }
     return result
   }
@@ -186,9 +186,11 @@ module.exports = class Bundle {
     return await this.drive.del(key)
   }
 
-  streamFrom (meta) {
-    if (this.trace && meta.value.blob) this.trace.capture([meta.value.blob.blockLength, meta.value.blob.blockOffset])
+  async streamFrom (key) {
+    const meta = await this.entry(key)
+    if (meta === null) return null
     const stream = this.drive.createReadStream(meta)
+    if (this.trace && meta.value.blob) await this.trace.capture([meta.value.blob.blockLength, meta.value.blob.blockOffset])
     return stream
   }
 

--- a/subsystems/sidecar/lib/http.js
+++ b/subsystems/sidecar/lib/http.js
@@ -164,11 +164,7 @@ module.exports = class Http extends ReadyResource {
         }
         app.warmup({ protocol, batch })
       }
-
-      const meta = await this.entry(link.filename)
-      if (meta === null) return
-
-      const stream = bundle.streamFrom(meta)
+      const stream = await bundle.streamFrom(link.filename)
       await streamx.pipelinePromise(stream, res)
     }
   }

--- a/subsystems/sidecar/lib/tracer.js
+++ b/subsystems/sidecar/lib/tracer.js
@@ -48,7 +48,7 @@ module.exports = class Tracer extends Readable {
     return (seq) => this.capture(seq, this.constructor.META)
   }
 
-  capture (seq, core = this.constructor.DATA) {
+  async capture (seq, core = this.constructor.DATA) {
     if (Array.isArray(seq)) {
       const [blockLength, blockOffset] = seq
       for (let i = 0; i < blockLength; i++) this.capture(i + blockOffset)


### PR DESCRIPTION
Reverts holepunchto/pear#262

pear run pear://keet errors in sidecar with this.entry is not found, displays same in ui 