### PR TITLE
return 404 from sidecar on ERR_HTTP_NOT_FOUND

### DIFF
--- a/subsystems/sidecar/lib/http.js
+++ b/subsystems/sidecar/lib/http.js
@@ -46,6 +46,9 @@ module.exports = class Http extends ReadyResource {
       } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND') {
           err.status = err.status || 404
+        } else if (err.code === 'ERR_HTTP_NOT_FOUND') {
+          err.status = err.status || 404
+          console.log(err)
         } else if (err.code === 'SESSION_CLOSED') {
           err.status = err.status || 503
         } else {

--- a/subsystems/sidecar/lib/http.js
+++ b/subsystems/sidecar/lib/http.js
@@ -48,7 +48,6 @@ module.exports = class Http extends ReadyResource {
           err.status = err.status || 404
         } else if (err.code === 'ERR_HTTP_NOT_FOUND') {
           err.status = err.status || 404
-          console.log(err)
         } else if (err.code === 'SESSION_CLOSED') {
           err.status = err.status || 503
         } else {


### PR DESCRIPTION
ERR_HTTP_NOT_FOUND is an expected kind of error, so I think it should return 404 instead of an internal-server error

<strike>Note: I can find no reference to the existing 2 error codes anywhere in the code base, so if those are supposed to be errors defined at Pear level, I believe they are outdated.</strike>
This has been clarified: those errors come from dependencies of pear, not from pear itself