### PR TITLE
Fix `--checkout release` flag not working when doing `pear dump`

### DIFF
--- a/subsystems/sidecar/ops/dump.js
+++ b/subsystems/sidecar/ops/dump.js
@@ -18,7 +18,7 @@ module.exports = class Dump extends Opstream {
       ? path.basename(parsed.pathname)
       : null
     const key = parsed.drive.key
-    checkout = Number(checkout)
+    if (checkout !== 'release') checkout = Number(checkout)
 
     const bundle = new Bundle({
       corestore: isFileLink ? null : sidecar._getCorestore(null, null),


### PR DESCRIPTION
Fixes bug where the `--checkout release` flag in `pear dump` dumps the most recently staged instead of the last release