### PR TITLE
Add support for whitelisting all links

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1076,7 +1076,7 @@ class Window extends GuiCtrl {
     const requestFilter = (details, respond) => {
       const url = new URL(details.url)
       const isAllowed = allowedHosts.some(({ protocol, hostname, port }) =>
-        protocol === url.protocol && hostname === url.hostname && (port === '' || port === url.port))
+        protocol === url.protocol && (hostname === '*' || hostname === url.hostname) && (port === '' || port === url.port))
       respond({ cancel: isAllowed === false })
     }
 


### PR DESCRIPTION
Adds support for `https://*` and `http://*` in the pear.links field in package.json which whitelists all links depending on protocol.

Resolves #277 