### PR TITLE
Improve ci run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - main
       - next
   pull_request:
+  repository_dispatch:
+  workflow_dispatch:
 jobs:
   build:
     strategy:
@@ -22,6 +24,7 @@ jobs:
           platform: win32
           arch: x64
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
     - name: Checkout
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 https://github.com/actions/checkout/releases/tag/v4.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: Build Status
 on:
+  schedule:
+    - cron:  '0 10 * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
This PR adds a CI timeout, a daily run and workflow dispatch that adds the possibility of triggering the workflow from other repositories. (see https://github.com/holepunchto/canary-tests/blob/main/.github/workflows/ci.yml#L15) 