### PR TITLE
Improve win titlebar

### DIFF
--- a/preload.js
+++ b/preload.js
@@ -228,7 +228,7 @@ if (process.isMainFrame) {
     constructor () {
       super()
       this.template = document.createElement('template')
-      this.template.innerHTML = isWindows ? this.#win() : (isMac ? this.#mac() : this.#gen())
+      this.template.innerHTML = isMac ? this.#mac() : this.#gen()
       this.root = this.attachShadow({ mode: 'open' })
       this.root.appendChild(this.template.content.cloneNode(true))
       this.#onfocus = () => this.root.querySelector('#ctrl').classList.add('focused')
@@ -249,72 +249,6 @@ if (process.isMainFrame) {
     }
 
     async #close () { await Pear.Window.self.close() }
-    #win () {
-      return `
-    <style>
-      #ctrl {
-        user-select: none;
-        -webkit-app-region: no-drag;
-        display: table-row;
-        float: right;
-        margin-left: .6em;
-        margin-top: 0.22em;
-        border-spacing: 0.3em 0;
-      }
-      #ctrl > .ctrl {
-        opacity: 0.8;
-        height: 24px;
-        width: 24px;
-        display: table-cell;
-        vertical-align: middle;
-        text-align: center;
-      }
-      #ctrl > .ctrl:hover {
-        opacity: 1;
-      }
-      .max #max  {
-        display: none;
-      }
-      #restore.ctrl  {
-        display: none;
-      }
-      .max #restore.ctrl  {
-        display: table-cell;
-      }
-
-    </style>
-    <div id="ctrl">
-      <div id="min" class="ctrl">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M19 12.998H5V10.998H19V12.998Z" fill="white"/>
-        </svg>
-      </div>
-      <div id="max" class="ctrl">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <rect x="6" y="6" width="12" height="12" stroke="white" stroke-width="2"/>
-        </svg>
-      </div>
-      <div id="restore" class="ctrl">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <g clip-path="url(#clip0_9105_112084)">
-            <path fill-rule="evenodd" clip-rule="evenodd" d="M8.11108 6H17.2222V15.1111H19.2222V5V4H18.2222H8.11108V6ZM6 10.3333H12.8889V17.2222H6V10.3333ZM4 8.33333H6H12.8889H14.8889V10.3333V17.2222V19.2222H12.8889H6H4V17.2222V10.3333V8.33333Z" fill="white"/>
-          </g>
-          <defs>
-            <clipPath id="clip0_9105_112084">
-              <rect width="24" height="24" fill="white"/>
-            </clipPath>
-          </defs>
-        </svg>      
-      </div>
-      <div id="close" class="ctrl">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path d="M6.4 19L5 17.6L10.6 12L5 6.4L6.4 5L12 10.6L17.6 5L19 6.4L13.4 12L19 17.6L17.6 19L12 13.4L6.4 19Z" fill="white"/>
-        </svg>
-      </div>
-    </div>
-    `
-    }
-
     #mac () {
       return `
       <style>:host {display: block;}</style>
@@ -323,7 +257,6 @@ if (process.isMainFrame) {
     }
 
     #gen () {
-      // linux uses frame atm
       return `
         <style>
           #ctrl {


### PR DESCRIPTION
This PR improves pear-ctrl to use the same titlebar for windows and linux, and removes duplicated code. See windows screenshots:

Before:
![image](https://github.com/user-attachments/assets/71c43a85-ff6c-461a-8a9d-2da44a22259e)
After:
![image](https://github.com/user-attachments/assets/2f274de1-37ff-442a-bed0-d42d0bf4bc64)
