### PR TITLE
added touch command

### DIFF
--- a/cmd/iface.js
+++ b/cmd/iface.js
@@ -141,7 +141,7 @@ and then becomes the sidecar.`,
 
   dev: `Alias for: ${ansi.italic('pear run --dev <dir>')}`,
 
-  touch: 'If channel name is not specified, a random 16 bytes hex name will be used.'
+  touch: 'Creates a Pear Link using provided channel name if provided or else a randomly generated channel name.'
 
 }
 

--- a/cmd/iface.js
+++ b/cmd/iface.js
@@ -139,7 +139,9 @@ provides access to corestores.
 This command instructs any existing sidecar process to shutdown
 and then becomes the sidecar.`,
 
-  dev: `Alias for: ${ansi.italic('pear run --dev <dir>')}`
+  dev: `Alias for: ${ansi.italic('pear run --dev <dir>')}`,
+
+  touch: 'If channel name is not specified, a random 16 bytes hex name will be used.'
 
 }
 

--- a/cmd/iface.js
+++ b/cmd/iface.js
@@ -141,7 +141,7 @@ and then becomes the sidecar.`,
 
   dev: `Alias for: ${ansi.italic('pear run --dev <dir>')}`,
 
-  touch: 'Creates a Pear Link using provided channel name if provided or else a randomly generated channel name.'
+  touch: 'Creates a Pear Link using channel name if provided or else a randomly generated channel name.'
 
 }
 

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -11,6 +11,7 @@ const runners = {
   release: require('./release'),
   info: require('./info'),
   dump: require('./dump'),
+  touch: require('./touch'),
   shift: require('./shift'),
   sidecar: require('./sidecar'),
   gc: require('./gc'),
@@ -125,6 +126,15 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     runners.dump(ipc)
   )
 
+  const touch = command(
+    'touch',
+    summary('Get channel key by name'),
+    description(usage.descriptions.touch),
+    arg('<channel>', 'Channel name'),
+    flag('--json', 'Newline delimited JSON output'),
+    runners.touch(ipc)
+  )
+
   const shift = command(
     'shift',
     summary('Advanced. Move storage between apps'),
@@ -185,6 +195,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     release,
     info,
     dump,
+    touch,
     shift,
     sidecar,
     gc,

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -128,9 +128,9 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
 
   const touch = command(
     'touch',
-    summary('Get channel key by name'),
+    summary('Create Pear link'),
     description(usage.descriptions.touch),
-    arg('<channel>', 'Channel name'),
+    arg('[channel]', 'Channel name'),
     flag('--json', 'Newline delimited JSON output'),
     runners.touch(ipc)
   )

--- a/cmd/touch.js
+++ b/cmd/touch.js
@@ -1,0 +1,31 @@
+'use strict'
+const { outputter, ansi } = require('./iface')
+const { randomBytes } = require('hypercore-crypto')
+const os = require('bare-os')
+
+const output = outputter('touch', {
+  header (str) { return `${str}\n` },
+  channel (channel) { return `${ansi.bold(channel)}:` },
+  key (key) { return `${key}` },
+  json (data) { return JSON.stringify(data, 0, 2) },
+  newline () { return '' }
+})
+
+module.exports = (ipc) => async function touch (cmd) {
+  const dir = os.cwd()
+  const json = cmd.flags.json
+  const channel = cmd.args.channel || randomBytes(16).toString('hex')
+  const key = await ipc.touch({ dir, channel })
+  await output(false, out({ json, channel, key, header: cmd.command.header }))
+}
+
+async function * out ({ json, channel, key, header }) {
+  if (json) {
+    yield { tag: 'json', data: { channel, key } }
+    return
+  }
+  yield { tag: 'header', data: header }
+  yield { tag: 'channel', data: channel }
+  yield { tag: 'key', data: key }
+  yield { tag: 'newline' }
+}

--- a/cmd/touch.js
+++ b/cmd/touch.js
@@ -4,28 +4,17 @@ const { randomBytes } = require('hypercore-crypto')
 const os = require('bare-os')
 
 const output = outputter('touch', {
-  header (str) { return `${str}\n` },
-  channel (channel) { return `${ansi.bold(channel)}:` },
-  key (key) { return `${key}` },
-  json (data) { return JSON.stringify(data, 0, 2) },
-  newline () { return '' }
+  result: ({ key }, { header, channel }) => {
+    return `${header}\n\n${ansi.bold(channel)}\n${key}\n`
+  },
+  error: ({ message }) => {
+    return `Error: ${message}\n`
+  }
 })
 
 module.exports = (ipc) => async function touch (cmd) {
   const dir = os.cwd()
   const json = cmd.flags.json
   const channel = cmd.args.channel || randomBytes(16).toString('hex')
-  const key = await ipc.touch({ dir, channel })
-  await output(false, out({ json, channel, key, header: cmd.command.header }))
-}
-
-async function * out ({ json, channel, key, header }) {
-  if (json) {
-    yield { tag: 'json', data: { channel, key } }
-    return
-  }
-  yield { tag: 'header', data: header }
-  yield { tag: 'channel', data: channel }
-  yield { tag: 'key', data: key }
-  yield { tag: 'newline' }
+  await output(json, ipc.touch({ dir, channel }), { channel, header: cmd.command.header })
 }

--- a/subsystems/sidecar/ops/touch.js
+++ b/subsystems/sidecar/ops/touch.js
@@ -1,0 +1,21 @@
+'use strict'
+const hypercoreid = require('hypercore-id-encoding')
+const { ERR_INVALID_PROJECT_DIR } = require('../../../errors')
+const State = require('../state')
+const Opstream = require('../lib/opstream')
+const Hyperdrive = require('hyperdrive')
+
+module.exports = class Touch extends Opstream {
+  constructor (...args) { super((...args) => this.#op(...args), ...args) }
+
+  async #op ({ dir, channel }) {
+    const { sidecar } = this
+    await sidecar.ready()
+    const state = new State({ dir, flags: {} })
+    if (!state.manifest) throw new ERR_INVALID_PROJECT_DIR(`"${state.pkgPath}" not found. Pear project must have a package.json`)
+    const corestore = sidecar._getCorestore(state.manifest.name, channel)
+    await corestore.ready()
+    const key = await Hyperdrive.getDriveKey(corestore)
+    this.push({ tag: 'result', data: { key: hypercoreid.normalize(key), channel } })
+  }
+}


### PR DESCRIPTION
Added `pear touch  [--json] [channel-name]`. The command return the key of the specified channel, if channel is empty, returns a random 16 bytes hex channel.

Output:

```
/hyper/pear$ peardev touch channel-name
Pear ~ Welcome to the Internet of Peers
🍐 v0.dev./home/rafapaezbas/hyper/pear

channel-name:
kxpwrcgg3mwtje1zs8kxztcthp4r6cshsdffdteaaefmahnaitro
```
```
/hyper/pear$ peardev touch --json channel-name
{
  "channel": "channel-name",
  "key": "kxpwrcgg3mwtje1zs8kxztcthp4r6cshsdffdteaaefmahnaitro"
}
```
```
/hyper/pear$ peardev touch
Pear ~ Welcome to the Internet of Peers
🍐 v0.dev./home/rafapaezbas/hyper/pear

ebba76fad79a7f99deb1bf9f92552112:
951knfd5gktgiq517qhoxy3j4op6pgfk1d4zbyxs53j1gfiai71o
```
```
/hyper/pear$ peardev touch --json
{
  "channel": "e7a2ee2d0adc847ddd26ef919266deb2",
  "key": "hmtutw4hm6ieoesynpkpaanyannzgt8bmbqmcysbyw64dg6wjgmo"
}
```


