### PR TITLE
Linux and Windows disable sandbox

### DIFF
--- a/electron-main.js
+++ b/electron-main.js
@@ -66,7 +66,7 @@ function configureElectron () {
 
   // Linux upgrades can effect chromium-sandbox, Windows has a similar issue with sandboxing
   // we already disable sandbox when opening the app window, so no security risk posed
-  if (isMac || process.argv.indexOf('--sandbox') === -1) electron.app.commandLine.appendSwitch('no-sandbox')
+  if (process.argv.indexOf('--sandbox') === -1) electron.app.commandLine.appendSwitch('no-sandbox')
 
   /* c8 ignore start */
   const inspix = process.argv.indexOf('--inspector-port')

--- a/electron-main.js
+++ b/electron-main.js
@@ -64,10 +64,6 @@ function configureElectron () {
 
   process.env.ELECTRON_DISABLE_SECURITY_WARNINGS = 'true'
 
-  // Linux upgrades can effect chromium-sandbox, Windows has a similar issue with sandboxing
-  // we already disable sandbox when opening the app window, so no security risk posed
-  if (process.argv.indexOf('--sandbox') === -1) electron.app.commandLine.appendSwitch('no-sandbox')
-
   /* c8 ignore start */
   const inspix = process.argv.indexOf('--inspector-port')
   if (inspix > -1) {

--- a/electron-main.js
+++ b/electron-main.js
@@ -66,7 +66,7 @@ function configureElectron () {
 
   // Linux upgrades can effect chromium-sandbox, Windows has a similar issue with sandboxing
   // we already disable sandbox when opening the app window, so no security risk posed
-  if (!isMac && process.argv.indexOf('--sandbox') === -1) electron.app.commandLine.appendSwitch('no-sandbox')
+  if (isMac || process.argv.indexOf('--sandbox') === -1) electron.app.commandLine.appendSwitch('no-sandbox')
 
   /* c8 ignore start */
   const inspix = process.argv.indexOf('--inspector-port')

--- a/run/definition.js
+++ b/run/definition.js
@@ -25,5 +25,5 @@ module.exports = [
   hiddenFlag('--trace <n>'),
   hiddenFlag('--swap <path>'),
   hiddenFlag('--start-id <id>'),
-  hiddenFlag('--sandbox') // enable electron/chromium sandbox
+  hiddenFlag('--no-sandbox') // electron passthrough
 ]

--- a/run/definition.js
+++ b/run/definition.js
@@ -25,5 +25,5 @@ module.exports = [
   hiddenFlag('--trace <n>'),
   hiddenFlag('--swap <path>'),
   hiddenFlag('--start-id <id>'),
-  hiddenFlag('--no-sandbox') // electron passthrough
+  hiddenFlag('--sandbox') // electron passthrough
 ]

--- a/run/index.js
+++ b/run/index.js
@@ -8,7 +8,7 @@ const ENV = require('bare-env')
 const { spawn } = require('bare-subprocess')
 const { pathToFileURL } = require('bare-url')
 const { Readable } = require('streamx')
-const { isMac, isWindows } = require('which-runtime')
+const { isMac, isWindows, isLinux } = require('which-runtime')
 const constants = require('../constants')
 const State = require('../state')
 const API = require('../lib/api')
@@ -83,6 +83,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
 
     if (link.startsWith('pear://runtime')) {
       args = [constants.BOOT, '--appling', appling, '--run', ...args]
+      if ((isLinux || isWindows) && !args.includes('--sandbox')) args.push('--no-sandbox')
       spawn(constants.DESKTOP_RUNTIME, args, opts).unref()
     } else {
       if (isMac) spawn('open', [applingApp, '--args', ...args], opts).unref()
@@ -148,6 +149,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
   if (type === 'desktop') {
     if (isPath) args[indices.args.link] = 'file://' + (base.entrypoint || '/')
     args[indices.args.link] = args[indices.args.link].replace('://', '_||') // for Windows
+    if ((isLinux || isWindows) && !args.includes('--sandbox')) args.push('--no-sandbox')
     args = [constants.BOOT, ...args]
     const stdio = detach ? 'ignore' : ['inherit', 'pipe', 'pipe']
     const child = spawn(constants.DESKTOP_RUNTIME, args, {

--- a/run/index.js
+++ b/run/index.js
@@ -83,7 +83,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
 
     if (link.startsWith('pear://runtime')) {
       args = [constants.BOOT, '--appling', appling, '--run', ...args]
-      if ((isLinux || isWindows) && !args.includes('--sandbox')) args.push('--no-sandbox')
+      if ((isLinux || isWindows) && !flags.sandbox) args.splice(indices.args.link, 0, '--no-sandbox')
       spawn(constants.DESKTOP_RUNTIME, args, opts).unref()
     } else {
       if (isMac) spawn('open', [applingApp, '--args', ...args], opts).unref()
@@ -149,7 +149,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
   if (type === 'desktop') {
     if (isPath) args[indices.args.link] = 'file://' + (base.entrypoint || '/')
     args[indices.args.link] = args[indices.args.link].replace('://', '_||') // for Windows
-    if ((isLinux || isWindows) && !args.includes('--sandbox')) args.push('--no-sandbox')
+    if ((isLinux || isWindows) && !flags.sandbox) args.splice(indices.args.link, 0, '--no-sandbox')
     args = [constants.BOOT, ...args]
     const stdio = detach ? 'ignore' : ['inherit', 'pipe', 'pipe']
     const child = spawn(constants.DESKTOP_RUNTIME, args, {

--- a/run/index.js
+++ b/run/index.js
@@ -8,7 +8,7 @@ const ENV = require('bare-env')
 const { spawn } = require('bare-subprocess')
 const { pathToFileURL } = require('bare-url')
 const { Readable } = require('streamx')
-const { isMac, isWindows, isLinux } = require('which-runtime')
+const { isMac, isWindows } = require('which-runtime')
 const constants = require('../constants')
 const State = require('../state')
 const API = require('../lib/api')
@@ -83,7 +83,6 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
 
     if (link.startsWith('pear://runtime')) {
       args = [constants.BOOT, '--appling', appling, '--run', ...args]
-      if (isLinux && hasRestrictedNamespaces()) args.push('--no-sandbox')
       spawn(constants.DESKTOP_RUNTIME, args, opts).unref()
     } else {
       if (isMac) spawn('open', [applingApp, '--args', ...args], opts).unref()
@@ -150,7 +149,6 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
     if (isPath) args[indices.args.link] = 'file://' + (base.entrypoint || '/')
     args[indices.args.link] = args[indices.args.link].replace('://', '_||') // for Windows
     args = [constants.BOOT, ...args]
-    if (isLinux && hasRestrictedNamespaces()) args.push('--no-sandbox')
     const stdio = detach ? 'ignore' : ['inherit', 'pipe', 'pipe']
     const child = spawn(constants.DESKTOP_RUNTIME, args, {
       stdio,
@@ -200,42 +198,4 @@ function project (dir, origin, cwd) {
     throw ERR_INVALID_INPUT(`A valid package.json file with pear field must exist ${condition}`)
   }
   return project(parent, origin, cwd)
-}
-
-async function hasRestrictedNamespaces () {
-  async function open (path) {
-    return new Promise((resolve, reject) => {
-      fs.open(path, 'r', (status, fd) => status ? reject(status) : resolve(fd))
-    })
-  }
-
-  async function read (fd, length) {
-    const buffer = Buffer.alloc(length)
-    return new Promise((resolve, reject) => {
-      fs.read(fd, buffer, 0, length, 0, function (err, num) {
-        if (err) {
-          reject(err)
-        } else {
-          resolve(buffer)
-        }
-      })
-    })
-  }
-
-  let appArmorRestrict = false
-  let unpriviledgeUsersRestrict = false
-
-  try {
-    const fd = await open('/proc/sys/kernel/apparmor_restrict_unprivileged_userns')
-    appArmorRestrict = (await read(fd, 1)).toString() === '1'
-  } catch {
-  }
-
-  try {
-    const fd = await open('/proc/sys/kernel/unprivileged_userns_clone')
-    unpriviledgeUsersRestrict = (await read(fd, 1)).toString() === '0'
-  } catch {
-  }
-
-  return appArmorRestrict || unpriviledgeUsersRestrict
 }


### PR DESCRIPTION
This pull request disables Chromium sand-boxing for Linux and Windows. The incompatibility of the sandbox with some Linux kernel parameters ie `apparmor_restrict_unprivileged_userns` and `unprivileged_userns_clone` forces some users to add the --no-sandbox in order to boot the platform. This is a Chromium known issue https://issues.chromium.org/issues/333313925 that affect Ubuntu 24 users and solved by Chrome by add a AppArmor profile. 
The same policy is applied to Windows.

Users can use the `--sandbox` flag to overwrite default behavior.