### PR TITLE
added test inspector dht bootstrap

### DIFF
--- a/test/fixtures/encrypted/index.js
+++ b/test/fixtures/encrypted/index.js
@@ -1,7 +1,7 @@
 import bareInspector from 'bare-inspector'
 import { Inspector } from 'pear-inspect'
 
-const inspector = new Inspector({ inspector: bareInspector })
+const inspector = new Inspector({ inspector: bareInspector, bootstrap: Pear.config.dht.bootstrap })
 const key = await inspector.enable()
 const inspectorKey = key.toString('hex')
 console.log(`{ "tag": "inspector", "data": { "key": "${inspectorKey}" }}`)

--- a/test/fixtures/harness/index.js
+++ b/test/fixtures/harness/index.js
@@ -12,7 +12,7 @@ class Harness extends ReadyResource {
   ipc = null
   sub = null
   async _open () {
-    this.inspector = new Inspector({ inspector: bareInspector })
+    this.inspector = new Inspector({ inspector: bareInspector, bootstrap: Pear.config.dht.bootstrap })
     this.key = await this.inspector.enable()
     this.inspectorKey = this.key.toString('hex')
     console.log(`{ "tag": "inspector", "data": { "key": "${this.inspectorKey}" }}`)

--- a/test/helper.js
+++ b/test/helper.js
@@ -268,7 +268,7 @@ class Helper extends IPC {
 
     constructor (key) {
       super()
-      this.#session = new Session({ inspectorKey: Buffer.from(key, 'hex') })
+      this.#session = new Session({ inspectorKey: Buffer.from(key, 'hex'), bootstrap: Pear.config.dht.bootstrap })
     }
 
     async _open () {


### PR DESCRIPTION
This PR removes production DHT usage of pear-inspect from tests. Depends on PR -> https://github.com/holepunchto/pear-inspect/pull/8