### PR TITLE
Extend the handler of the option --unsafe-clear-preferences to clear both preferences and permits

### DIFF
--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -467,6 +467,13 @@ class Sidecar extends ReadyResource {
     return permits.set('trusted', Array.from(trusted))
   }
 
+  async untrust (key) {
+    const z32 = hypercoreid.encode(key)
+    const trusted = new Set((await permits.get('trusted')) || [])
+    trusted.splice(trusted.indexOf(z32), 1); // remove key from trusted
+    return permits.set('trusted', Array.from(trusted))
+  }
+
   async trusted (key) {
     const z32 = hypercoreid.encode(key)
     const trusted = await permits.get('trusted') || []

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -470,7 +470,7 @@ class Sidecar extends ReadyResource {
   async untrust (key) {
     const z32 = hypercoreid.encode(key)
     const trusted = new Set((await permits.get('trusted')) || [])
-    trusted.splice(trusted.indexOf(z32), 1); // remove key from trusted
+    trusted.splice(trusted.indexOf(z32), 1) // remove key from trusted
     return permits.set('trusted', Array.from(trusted))
   }
 

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -467,13 +467,6 @@ class Sidecar extends ReadyResource {
     return permits.set('trusted', Array.from(trusted))
   }
 
-  async untrust (key) {
-    const z32 = hypercoreid.encode(key)
-    const trusted = new Set((await permits.get('trusted')) || [])
-    trusted.splice(trusted.indexOf(z32), 1) // remove key from trusted
-    return permits.set('trusted', Array.from(trusted))
-  }
-
   async trusted (key) {
     const z32 = hypercoreid.encode(key)
     const trusted = await permits.get('trusted') || []

--- a/subsystems/sidecar/state.js
+++ b/subsystems/sidecar/state.js
@@ -7,6 +7,7 @@ const Store = require('./lib/store')
 const SharedState = require('../../state')
 const { ERR_INVALID_PROJECT_DIR, ERR_INVALID_MANIFEST } = require('../../errors')
 const preferences = new Store('preferences')
+const permits = new Store('permits')
 
 module.exports = class State extends SharedState {
   initialized = false
@@ -70,7 +71,12 @@ module.exports = class State extends SharedState {
     this.update({ tier, name, main, options, dependencies, channel, release })
 
     if (this.clearAppStorage) await fsp.rm(this.storage, { recursive: true })
-    if (this.clearPreferences) await preferences.clear()
+    if (this.clearPreferences) {
+      await Promise.all([
+        preferences.clear().catch(() => undefined),
+        permits.clear().catch(() => undefined),
+      ]);
+    }
 
     await fsp.mkdir(this.storage, { recursive: true })
     try { this.checkpoint = JSON.parse(await fsp.readFile(path.join(this.storage, 'checkpoint'))) } catch { /* ignore */ }

--- a/subsystems/sidecar/state.js
+++ b/subsystems/sidecar/state.js
@@ -74,7 +74,7 @@ module.exports = class State extends SharedState {
     if (this.clearPreferences) {
       await Promise.all([
         preferences.clear().catch(() => undefined),
-        permits.clear().catch(() => undefined),
+        permits.clear().catch(() => undefined)
       ])
     }
 

--- a/subsystems/sidecar/state.js
+++ b/subsystems/sidecar/state.js
@@ -75,7 +75,7 @@ module.exports = class State extends SharedState {
       await Promise.all([
         preferences.clear().catch(() => undefined),
         permits.clear().catch(() => undefined),
-      ]);
+      ])
     }
 
     await fsp.mkdir(this.storage, { recursive: true })


### PR DESCRIPTION
# Context
- We would like doctor to test TrustDialog for new key
- To do that, we need to clear all `trusted` keys
- Then click/run on the key again
- The TrustDialog should open

# Summary
- extend the handler of the option `--unsafe-clear-preferences` to clear both preferences and permits

# Test
```
./pear.dev run --unsafe-clear-preferences pear://runtime
./pear.dev run pear://kpzdysqu3uqu3nz7xakidqb1ju71jbzaszxu58r3owodbujyghuy
```
![image](https://github.com/user-attachments/assets/0901a244-368e-4d20-86ee-ff6c8686c5a1)

