### PR TITLE
fixed timeout teardown for electron context

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -477,6 +477,10 @@ class App {
       }
     })
 
+    electron.app.on('app-exit', () => {
+      electron.app.exit()
+    })
+
     const { state } = this
 
     this.starting = this.ipc.start({

--- a/lib/api.js
+++ b/lib/api.js
@@ -71,9 +71,9 @@ class API {
     if (timedout) {
       console.error(`Max teardown wait reached after ${MAX_TEARDOWN_WAIT} ms. Exiting...`)
       if (global.Bare) {
-        Bare.exit()
+        Bare.exit(1)
       } else {
-        process.exit()
+        process.exit(1)
       }
     }
   }

--- a/lib/api.js
+++ b/lib/api.js
@@ -71,9 +71,10 @@ class API {
     if (timedout) {
       console.error(`Max teardown wait reached after ${MAX_TEARDOWN_WAIT} ms. Exiting...`)
       if (global.Bare) {
-        Bare.exit(1)
+        Bare.exit()
       } else {
-        process.exit(1)
+        const electron = require('electron')
+        electron.ipcRenderer.send('app-exit') // graceful electron shutdown
       }
     }
   }

--- a/lib/api.js
+++ b/lib/api.js
@@ -70,7 +70,11 @@ class API {
     await Promise.race([this.#teardowns, countdown])
     if (timedout) {
       console.error(`Max teardown wait reached after ${MAX_TEARDOWN_WAIT} ms. Exiting...`)
-      Bare.exit()
+      if (global.Bare) {
+        Bare.exit()
+      } else {
+        process.exit()
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes timeout teardown for desktop apps. It adds a check for global Bare, in case it does not exist, uses `process.exit` in order to close the app.