### PR TITLE
remove preferences API

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1525,20 +1525,6 @@ class PearGUI extends ReadyResource {
       }
       pipe.write(data)
     })
-
-    // DEPRECATED - assess to remove from Sep 2024
-    electron.ipcMain.on('preferences', (evt) => {
-      const preferences = this.preferences()
-      preferences.on('data', (data) => evt.reply('preferences', data))
-      preferences.on('end', () => evt.reply('preferences', null))
-    })
-    electron.ipcMain.handle('setPreference', (evt, ...args) => this.setPreference(...args))
-    electron.ipcMain.handle('getPreference', (evt, ...args) => this.getPreference(...args))
-    electron.ipcMain.on('iteratePreferences', (evt) => {
-      const iteratePreferences = this.iteratePreferences()
-      iteratePreferences.on('data', (data) => evt.reply('iteratePreferences', data))
-      iteratePreferences.on('end', () => evt.reply('iteratePreferences', null))
-    })
   }
 
   async app () {
@@ -1757,12 +1743,6 @@ class PearGUI extends ReadyResource {
   reports () { return this.ipc.reports() }
 
   permit (params) { return this.ipc.permit(params) }
-
-  // DEPRECATED - assess to remove from Sep 2024
-  preferences () { return this.ipc.preferences() }
-  setPreference (key, value) { return this.ipc.setPreference({ key, value }) }
-  async getPreference (key) { return this.ipc.getPreference({ key }) }
-  iteratePreference () { return this.ipc.iteratePreference() }
 }
 
 class Freelist {

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -317,27 +317,4 @@ class IPC {
 
   ref () {}
   unref () {}
-
-  // DEPRECATED - assess to remove from Sep 2024
-  preferences () {
-    electron.ipcRenderer.send('preferences')
-    const stream = new streamx.Readable()
-    electron.ipcRenderer.on('preferences', (e, data) => { stream.push(data) })
-    return stream
-  }
-
-  setPreference (key, value) {
-    return electron.ipcRenderer.invoke('setPreference', key, value)
-  }
-
-  getPreference (key) {
-    return electron.ipcRenderer.invoke('getPreference', key)
-  }
-
-  list () {
-    electron.ipcRenderer.send('iteratePreferences')
-    const stream = new streamx.Readable()
-    electron.ipcRenderer.on('iteratePreferences', (e, data) => { stream.push(data) })
-    return stream
-  }
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -131,18 +131,6 @@ class API {
   }
 
   exit = (code) => program.exit(code)
-
-  // DEPRECATED - assess to remove from Sep 2024
-  #preferences = null
-  get preferences () {
-    if (this.#preferences) return this.#preferences
-    this.#preferences = () => this.#ipc.preferences()
-    this.#preferences.set = (key, value) => this.#ipc.setPreference(key, value)
-    this.#preferences.get = (key) => this.#ipc.getPreference(key)
-    this.#preferences.del = (key) => this.#ipc.setPreference(key, null)
-    this.#preferences.list = () => this.#ipc.iteratePreferences()
-    return this.#preferences
-  }
 }
 
 module.exports = API

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -935,24 +935,6 @@ class Sidecar extends ReadyResource {
     return this.corestore.namespace(`${name}~${channel}`, { writable: false, ...opts })
   }
 
-  // DEPRECATED - assess for removal from Sep 2024
-  async * preferences () {
-    for await (const { data } of preferences.updates()) yield data
-  }
-
-  async setPreference ({ key, value }) {
-    const result = await preferences.set(key, value)
-    return result
-  }
-
-  async getPreference ({ key }) {
-    return await preferences.get(key)
-  }
-
-  async * iteratePreferences () {
-    yield * preferences.entries()
-  }
-
   async #shutdown (client) {
     LOG.info('sidecar', '- Sidecar Shutting Down...')
     const app = client.userData


### PR DESCRIPTION
### Remove deprecated Pear.preferences API
This PR depends on the merge and release of pear-ipc https://github.com/holepunchto/pear-ipc/pull/17
pear-docs https://github.com/holepunchto/pear-docs/pull/146/files
