### PR TITLE
Remove duplicate help text from `release` cmd

### DIFF
--- a/cmd/iface.js
+++ b/cmd/iface.js
@@ -114,9 +114,7 @@ ${urls}\n${ansi.bold(ansi.dim('Pear'))} ~ ${ansi.dim('Welcome to the IoP')}
 }
 
 const descriptions = {
-  release: `Set production release version.
-
-Set the release pointer against a version (default latest).
+  release: `Set the release pointer against a version (default latest).
 
 Use this to indicate production release points.`,
 


### PR DESCRIPTION
The 'Set production release versions.' line is already included as the command summary [here](https://github.com/holepunchto/pear/blob/c7873e3840e58bbb02f90778d96e5a9b30695beb/cmd/index.js#L88).