### PR TITLE
Add param `--external-corestore` to `scripts/bootstrap.js`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "archdump": "node scripts/bootstrap.js --archdump",
-    "prestage": "node scripts/bootstrap.js --archdump --store-path ${STORE_PATH:-/tmp/pear-build/dev} && node scripts/prune-dual-prebuilds.mjs",
+    "prebuild": "node scripts/bootstrap.js --archdump --store-path ${STORE_PATH:-/tmp/pear-build/dev} && node scripts/prune-dual-prebuilds.mjs",
     "bootstrap": "node scripts/bootstrap.js"
   },
   "author": "Holepunch",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "archdump": "node scripts/bootstrap.js --archdump",
-    "prestage": "node scripts/bootstrap.js --archdump --store-path ${STORE_PATH:-dev} && node scripts/prune-dual-prebuilds.mjs",
+    "prestage": "node scripts/bootstrap.js --archdump --store-path ${STORE_PATH:-/tmp/pear-build/dev} && node scripts/prune-dual-prebuilds.mjs",
     "bootstrap": "node scripts/bootstrap.js"
   },
   "author": "Holepunch",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "lint:fix": "standard --fix",
     "archdump": "node scripts/bootstrap.js --archdump",
     "prestage": "node scripts/bootstrap.js --archdump --external-corestore && node scripts/prune-dual-prebuilds.mjs",
-    "prebuild": "node scripts/prune-dual-prebuilds.mjs",
     "bootstrap": "node scripts/bootstrap.js"
   },
   "author": "Holepunch",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "archdump": "node scripts/bootstrap.js --archdump",
-    "prebuild": "node scripts/bootstrap.js --archdump --store-path ${STORE_PATH:-/tmp/pear-build/dev} && node scripts/prune-dual-prebuilds.mjs",
+    "prebuild": "node scripts/bootstrap.js --archdump --corestore ${CORESTORE_PATH:-/tmp/pear-build/dev} && node scripts/prune-dual-prebuilds.mjs",
     "bootstrap": "node scripts/bootstrap.js"
   },
   "author": "Holepunch",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "archdump": "node scripts/bootstrap.js --archdump",
+    "prestage": "node scripts/bootstrap.js --archdump --external-corestore && node scripts/prune-dual-prebuilds.mjs",
     "prebuild": "node scripts/prune-dual-prebuilds.mjs",
     "bootstrap": "node scripts/bootstrap.js"
   },

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "archdump": "node scripts/bootstrap.js --archdump",
+    "prebuild": "node scripts/prune-dual-prebuilds.mjs",
     "bootstrap": "node scripts/bootstrap.js"
   },
   "author": "Holepunch",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "archdump": "node scripts/bootstrap.js --archdump",
-    "prebuild": "node scripts/bootstrap.js --archdump --corestore ${CORESTORE_PATH:-/tmp/pear-build/dev} && node scripts/prune-dual-prebuilds.mjs",
     "bootstrap": "node scripts/bootstrap.js"
   },
   "author": "Holepunch",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "lint": "standard",
     "lint:fix": "standard --fix",
     "archdump": "node scripts/bootstrap.js --archdump",
-    "prestage": "npm run archdump && node scripts/prune-dual-prebuilds.mjs",
+    "prestage": "node scripts/bootstrap.js --archdump --store-path ${STORE_PATH:-dev} && node scripts/prune-dual-prebuilds.mjs",
     "bootstrap": "node scripts/bootstrap.js"
   },
   "author": "Holepunch",

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -4,6 +4,7 @@
 const { platform, arch, isWindows, isBare } = require('which-runtime')
 const fs = isBare ? require('bare-fs') : require('fs')
 const path = isBare ? require('bare-path') : require('path')
+const { command, flag, rest } = require('paparam')
 const Corestore = require('corestore')
 const Localdrive = require('localdrive')
 const Hyperdrive = require('hyperdrive')
@@ -15,15 +16,25 @@ const safetyCatch = require('safety-catch')
 const Rache = require('rache')
 
 const argv = global.Pear?.config.args || global.Bare?.argv || global.process.argv
+
+const parser = command('bootstrap',
+  flag('--archdump'),
+  flag('--dlruntime'),
+  flag('--corestore <path>'),
+  rest('rest')
+)
+const cmd = parser.parse(argv.slice(2), { sync: true })
+
+const ARCHDUMP = cmd.flags.archdump === true
+const DLRUNTIME = cmd.flags.dlruntime === true
+const CORESTORE_PATH = cmd.flags.corestore
+const RUNTIMES_DRIVE_KEY = cmd.rest?.[0] || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
+
 const ROOT = global.Pear ? path.join(new URL(global.Pear.config.applink).pathname, __dirname) : __dirname
 const ADDON_HOST = require.addon?.host || platform + '-' + arch
 const PEAR = path.join(ROOT, '..', 'pear')
 const SWAP = path.join(ROOT, '..')
 const HOST = path.join(SWAP, 'by-arch', ADDON_HOST)
-const ARCHDUMP = argv.includes('--archdump')
-const CORESTORE_PATH = argv.includes('--corestore') ? argv[argv.indexOf('--corestore') + 1] : null
-const DLRUNTIME = argv.includes('--dlruntime')
-const RUNTIMES_DRIVE_KEY = argv.slice(2).find(([ch]) => ch !== '-') || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 try {
   fs.symlinkSync('..', path.join(PEAR, 'current'), !isWindows ? 'junction' : 'file')
 } catch (err) {

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -27,7 +27,7 @@ const cmd = parser.parse(argv.slice(2), { sync: true })
 
 const ARCHDUMP = cmd.flags.archdump === true
 const DLRUNTIME = cmd.flags.dlruntime === true
-const CORESTORE = cmd.flags.externalCorestore && 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
+const CORESTORE = cmd.flags.externalCorestore ? '/tmp/pear-archdump/gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho' : null
 const RUNTIMES_DRIVE_KEY = cmd.rest?.[0] || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 
 const ROOT = global.Pear ? path.join(new URL(global.Pear.config.applink).pathname, __dirname) : __dirname

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -21,7 +21,7 @@ const PEAR = path.join(ROOT, '..', 'pear')
 const SWAP = path.join(ROOT, '..')
 const HOST = path.join(SWAP, 'by-arch', ADDON_HOST)
 const ARCHDUMP = argv.includes('--archdump')
-const STORE_PATH = argv.includes('--store-path') ? argv[argv.indexOf('--store-path') + 1] : null
+const CORESTORE_PATH = argv.includes('--corestore') ? argv[argv.indexOf('--corestore') + 1] : null
 const DLRUNTIME = argv.includes('--dlruntime')
 const RUNTIMES_DRIVE_KEY = argv.slice(2).find(([ch]) => ch !== '-') || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 try {
@@ -74,7 +74,7 @@ async function * downloader (key, all) {
   if (all) yield '🍐 Fetching all runtimes from: \n   ' + key
   else yield '🍐 [ localdev ] - no local runtime: fetching runtime'
 
-  const store = STORE_PATH || path.join(PEAR, 'corestores', 'platform')
+  const store = CORESTORE_PATH || path.join(PEAR, 'corestores', 'platform')
 
   const maxCacheSize = 65536
   const globalCache = new Rache({ maxSize: maxCacheSize })

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -27,7 +27,7 @@ const cmd = parser.parse(argv.slice(2), { sync: true })
 
 const ARCHDUMP = cmd.flags.archdump === true
 const DLRUNTIME = cmd.flags.dlruntime === true
-const CORESTORE = cmd.flags.externalCorestore ? '/tmp/pear-archdump/gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho' : null
+const CORESTORE = cmd.flags.externalCorestore && '/tmp/pear-archdump/gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 const RUNTIMES_DRIVE_KEY = cmd.rest?.[0] || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 
 const ROOT = global.Pear ? path.join(new URL(global.Pear.config.applink).pathname, __dirname) : __dirname

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -20,14 +20,14 @@ const argv = global.Pear?.config.args || global.Bare?.argv || global.process.arg
 const parser = command('bootstrap',
   flag('--archdump'),
   flag('--dlruntime'),
-  flag('--corestore <path>'),
+  flag('--external-corestore'),
   rest('rest')
 )
 const cmd = parser.parse(argv.slice(2), { sync: true })
 
 const ARCHDUMP = cmd.flags.archdump === true
 const DLRUNTIME = cmd.flags.dlruntime === true
-const CORESTORE = cmd.flags.corestore
+const CORESTORE = cmd.flags.externalCorestore && 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 const RUNTIMES_DRIVE_KEY = cmd.rest?.[0] || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 
 const ROOT = global.Pear ? path.join(new URL(global.Pear.config.applink).pathname, __dirname) : __dirname

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -21,6 +21,7 @@ const PEAR = path.join(ROOT, '..', 'pear')
 const SWAP = path.join(ROOT, '..')
 const HOST = path.join(SWAP, 'by-arch', ADDON_HOST)
 const ARCHDUMP = argv.includes('--archdump')
+const STORE_PATH = argv.includes('--store-path') ? argv[argv.indexOf('--store-path') + 1] : null
 const DLRUNTIME = argv.includes('--dlruntime')
 const RUNTIMES_DRIVE_KEY = argv.slice(2).find(([ch]) => ch !== '-') || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 try {
@@ -73,7 +74,7 @@ async function * downloader (key, all) {
   if (all) yield '🍐 Fetching all runtimes from: \n   ' + key
   else yield '🍐 [ localdev ] - no local runtime: fetching runtime'
 
-  const store = path.join(PEAR, 'corestores', 'platform')
+  const store = STORE_PATH || path.join(PEAR, 'corestores', 'platform')
 
   const maxCacheSize = 65536
   const globalCache = new Rache({ maxSize: maxCacheSize })

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -27,8 +27,8 @@ const cmd = parser.parse(argv.slice(2), { sync: true })
 
 const ARCHDUMP = cmd.flags.archdump === true
 const DLRUNTIME = cmd.flags.dlruntime === true
-const CORESTORE = cmd.flags.externalCorestore && '/tmp/pear-archdump/gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 const RUNTIMES_DRIVE_KEY = cmd.rest?.[0] || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
+const CORESTORE = cmd.flags.externalCorestore && `/tmp/pear-archdump/${RUNTIMES_DRIVE_KEY}`
 
 const ROOT = global.Pear ? path.join(new URL(global.Pear.config.applink).pathname, __dirname) : __dirname
 const ADDON_HOST = require.addon?.host || platform + '-' + arch

--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -27,7 +27,7 @@ const cmd = parser.parse(argv.slice(2), { sync: true })
 
 const ARCHDUMP = cmd.flags.archdump === true
 const DLRUNTIME = cmd.flags.dlruntime === true
-const CORESTORE_PATH = cmd.flags.corestore
+const CORESTORE = cmd.flags.corestore
 const RUNTIMES_DRIVE_KEY = cmd.rest?.[0] || 'gd4n8itmfs6x7tzioj6jtxexiu4x4ijiu3grxdjwkbtkczw5dwho'
 
 const ROOT = global.Pear ? path.join(new URL(global.Pear.config.applink).pathname, __dirname) : __dirname
@@ -85,7 +85,7 @@ async function * downloader (key, all) {
   if (all) yield '🍐 Fetching all runtimes from: \n   ' + key
   else yield '🍐 [ localdev ] - no local runtime: fetching runtime'
 
-  const store = CORESTORE_PATH || path.join(PEAR, 'corestores', 'platform')
+  const store = CORESTORE || path.join(PEAR, 'corestores', 'platform')
 
   const maxCacheSize = 65536
   const globalCache = new Rache({ maxSize: maxCacheSize })


### PR DESCRIPTION
# Summary
if `--external-corestore` is set, set corestore to `/tmp/pear-archdump/<archdump key>`

# Test

```
cd keet-automation

./runner.mjs -s ce70c330f62dca492adcf54bfc89a7cb15a119a511d8f0b4ea477f5023b83160

./client.mjs -s ce70c330f62dca492adcf54bfc89a7cb15a119a511d8f0b4ea477f5023b83160 -r dcdc8039da38a92e2fc71c91d77326fbdc15e5e50d484f4221a32334754914b1 pear-platform --commit 95857e07e0820dba36ea30c8af4afe656713574e --channel dev
```

