### PR TITLE
hotfix Bump Version on Merged

### DIFF
--- a/.github/workflows/bump-version-merged.yml
+++ b/.github/workflows/bump-version-merged.yml
@@ -26,6 +26,7 @@ jobs:
 
 
   pre-build:
+    needs: tag
     runs-on: ubuntu-latest
     outputs:
       channel: ${{ steps.prepare-channel.outputs.channel }}


### PR DESCRIPTION
require job `tag` to run next jobs