### PR TITLE
Logger parse level bug fix (TRACE or 3)

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -22,6 +22,7 @@ class Logger {
     }
   }
 
+  get OFF () { return this.LEVEL === 0 }
   get ERR () { return this.LEVEL === 1 }
   get INF () { return this.LEVEL === 2 }
   get TRC () { return this.LEVEL === 3 }
@@ -98,7 +99,7 @@ class Logger {
     if (level === 'ERR' || level === 'ERROR' || level === '1') return 1
     if (level === 'INF' || level === 'INFO' || level === '2') return 2
     if (level === 'TRC' || level === 'TRACE' || level === 'TRA' || level === '3') return 3
-    return 1
+    return 2
   }
 
   _parseFields (fields) {

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -95,8 +95,9 @@ class Logger {
     if (typeof level !== 'string') return level
     level = level.toUpperCase()
     if (level === 'OFF' || level === '0') return 0
-    if (level === 'INF' || level === 'INFO' || level === '1') return 1
-    if (level === 'TRC' || level === 'TRACE' || level === 'TRA' || level === '2') return 2
+    if (level === 'ERR' || level === 'ERROR' || level === '1') return 1
+    if (level === 'INF' || level === 'INFO' || level === '2') return 2
+    if (level === 'TRC' || level === 'TRACE' || level === 'TRA' || level === '3') return 3
     return 1
   }
 

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -929,7 +929,7 @@ class Sidecar extends ReadyResource {
     if (this.dhtBootstrap) LOG.info('sidecar', 'DHT bootstrap set', this.dhtBootstrap)
     const nodes = this.dhtBootstrap ? undefined : await knownNodes.get('nodes')
     if (nodes) {
-      LOG.info('sidecar', 'DHT known-nodes read from file ' + nodes.length + ' nodes')
+      LOG.info('sidecar', '- DHT known-nodes read from file ' + nodes.length + ' nodes')
       LOG.trace('sidecar', nodes.map(node => `  - ${node.host}:${node.port}`).join('\n'))
     }
     this.swarm = new Hyperswarm({ keyPair: this.keyPair, bootstrap: this.dhtBootstrap, nodes })

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -926,11 +926,11 @@ class Sidecar extends ReadyResource {
       throw err
     }
     this.keyPair = await this.corestore.createKeyPair('holepunch')
-    if (this.dhtBootstrap) LOG.info('sidecar', 'DHT bootstrap set ', this.dhtBootstrap)
+    if (this.dhtBootstrap) LOG.info('sidecar', 'DHT bootstrap set', this.dhtBootstrap)
     const nodes = this.dhtBootstrap ? undefined : await knownNodes.get('nodes')
     if (nodes) {
-      LOG.info('sidecar', 'DHT known nodes read from file ' + nodes.length + ' nodes')
-      LOG.trace('sidecar', nodes)
+      LOG.info('sidecar', 'DHT known-nodes read from file ' + nodes.length + ' nodes')
+      LOG.trace('sidecar', JSON.stringify(nodes, null, 2))
     }
     this.swarm = new Hyperswarm({ keyPair: this.keyPair, bootstrap: this.dhtBootstrap, nodes })
     this.swarm.once('close', () => { this.swarm = null })
@@ -968,8 +968,8 @@ class Sidecar extends ReadyResource {
         const nodes = this.swarm.dht.toArray({ limit: KNOWN_NODES_LIMIT })
         if (nodes.length) {
           await knownNodes.set('nodes', nodes)
-          LOG.info('sidecar', 'DHT known nodes wrote to file ' + nodes.length + ' nodes')
-          LOG.trace('sidecar', nodes)
+          LOG.info('sidecar', 'DHT known-nodes wrote to file ' + nodes.length + ' nodes')
+          LOG.trace('sidecar', JSON.stringify(nodes, null, 2))
         }
       }
       await this.swarm.destroy()

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -930,7 +930,7 @@ class Sidecar extends ReadyResource {
     const nodes = this.dhtBootstrap ? undefined : await knownNodes.get('nodes')
     if (nodes) {
       LOG.info('sidecar', 'DHT known-nodes read from file ' + nodes.length + ' nodes')
-      LOG.trace('sidecar', JSON.stringify(nodes, null, 2))
+      LOG.trace('sidecar', nodes.map(node => `  - ${node.host}:${node.port}`).join('\n'))
     }
     this.swarm = new Hyperswarm({ keyPair: this.keyPair, bootstrap: this.dhtBootstrap, nodes })
     this.swarm.once('close', () => { this.swarm = null })
@@ -968,8 +968,8 @@ class Sidecar extends ReadyResource {
         const nodes = this.swarm.dht.toArray({ limit: KNOWN_NODES_LIMIT })
         if (nodes.length) {
           await knownNodes.set('nodes', nodes)
-          LOG.info('sidecar', 'DHT known-nodes wrote to file ' + nodes.length + ' nodes')
-          LOG.trace('sidecar', JSON.stringify(nodes, null, 2))
+          LOG.info('sidecar', '- DHT known-nodes wrote to file ' + nodes.length + ' nodes')
+          LOG.trace('sidecar', nodes.map(node => `  - ${node.host}:${node.port}`).join('\n'))
         }
       }
       await this.swarm.destroy()


### PR DESCRIPTION
Two bugs:

1. parse was missing to handle TRACE=3
2. fallback value was ERROR=1 instead of INFO=2, because the enum in parse function had the wrong count

Based on the --help

```
    --log-level <level>   Level to log at. 0,1,2,3 (OFF,ERR,INF,TRC)
```

* `./pear.dev sidecar --log-level 3` now works as expected

* improvements to known-nodes logging (dump entire array instead of " ... 11 more", more compact output)

<img width="721" alt="image" src="https://github.com/user-attachments/assets/e3647804-ac7c-44ae-ac3f-b1f530f86ab1">


