### PR TITLE
Fix spelling error in `trust()`

### DIFF
--- a/cmd/iface.js
+++ b/cmd/iface.js
@@ -162,8 +162,8 @@ async function trust (ipc, key, cmd) {
   }
 
   const ask = {
-    run: 'Tust application',
-    init: 'Tust template'
+    run: 'Trust application',
+    init: 'Trust template'
   }
 
   const z32 = hypercoreid.encode(key)


### PR DESCRIPTION
Fixes a minor spelling mistake in the trust workflow. 'Tust' vs 'Trust'.