### PR TITLE
Move version flag to main `pear` command

### DIFF
--- a/cmd/index.js
+++ b/cmd/index.js
@@ -208,6 +208,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     encryptionKey,
     versions,
     help,
+    flag('-v', 'Print version'),
     footer(usage.footer),
     bail(explain),
     pear

--- a/def/pear.js
+++ b/def/pear.js
@@ -2,7 +2,6 @@
 const { flag } = require('paparam')
 
 module.exports = [
-  flag('-v', 'Print version'),
   flag('--log-level <level>', 'Level to log at. 0,1,2,3 (OFF,ERR,INF,TRC)'),
   flag('--log-labels <list>', 'Labels to log (internal, always logged)'),
   flag('--log-fields <list>', 'Show/hide: date,time,h:level,h:label,h:delta'),


### PR DESCRIPTION
This PR was motivated by the `-v` and the `--sidecar` being listend in the output from `pear help sidecar`. The verbose flag (`-v`) is only used [in the main `pear` command](https://github.com/holepunchto/pear/blob/9f9283fb291e45b1b7b2c1dee1e276832e3ade84/cmd/index.js#L217) that I can tell.

I tried moving `--sidecar` as well since the `sidecar` command doesn't seem to use it (and it sounds redundant to 'Boot Sidecar' from a command to run a sidecar in the terminal), but when I did this tests no longer passed. I tracked it down to the flag being added via [`shell.js`](https://github.com/holepunchto/pear/blob/9f9283fb291e45b1b7b2c1dee1e276832e3ade84/shell.js#L4) and triggered by [`lib/tryboot.js`](https://github.com/holepunchto/pear/blob/9f9283fb291e45b1b7b2c1dee1e276832e3ade84/lib/tryboot.js#L27). So I left it in for the moment, but it'd be nice to not include it in `pear sidecar` if it indeed doesn't do anything.