### PR TITLE
Improve worker runtime + teardown

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,6 +1,7 @@
 'use strict'
 const { isElectronRenderer, isWindows, isBare } = require('which-runtime')
 const fs = isBare ? require('bare-fs') : require('fs')
+const teardown = isBare ? require('./teardown') : () => undefined
 const { spawn } = isBare ? require('bare-subprocess') : require('child_process')
 const { command } = require('paparam')
 const Pipe = isBare
@@ -16,6 +17,7 @@ class Worker {
   #ref = null
   #unref = null
   #ipc = null
+  static RUNTIME = constants.RUNTIME
   constructor ({ ref = noop, unref = noop, ipc = null } = {}) {
     this.#ref = ref
     this.#unref = unref
@@ -41,7 +43,7 @@ class Worker {
   run (link, args = []) {
     if (isElectronRenderer) return this.#ipc.workerRun(link, args)
     args = [...this.#args(link), ...args]
-    const sp = spawn(constants.RUNTIME, args, {
+    const sp = spawn(this.constructor.RUNTIME, args, {
       stdio: ['inherit', 'inherit', 'inherit', 'overlapped'],
       windowsHide: true
     })
@@ -67,11 +69,12 @@ class Worker {
       return null
     }
     const pipe = new Pipe(fd)
-    pipe.on('end', () => pipe.end())
+    pipe.on('end', () => {
+      teardown(async () => pipe.end(), Number.MAX_SAFE_INTEGER)
+    })
     this.#pipe = pipe
     pipe.once('close', () => {
-      // allow close event to propagate between processes before exiting:
-      setImmediate(() => program.exit())
+      teardown(async () => program.exit(), Number.MAX_SAFE_INTEGER)
     })
     return pipe
   }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,7 +1,7 @@
 'use strict'
 const { isElectronRenderer, isWindows, isBare } = require('which-runtime')
 const fs = isBare ? require('bare-fs') : require('fs')
-const teardown = isBare ? require('./teardown') : () => undefined
+const teardown = isBare ? require('./teardown') : (fn) => fn()
 const { spawn } = isBare ? require('bare-subprocess') : require('child_process')
 const { command } = require('paparam')
 const Pipe = isBare
@@ -70,11 +70,11 @@ class Worker {
     }
     const pipe = new Pipe(fd)
     pipe.on('end', () => {
-      teardown(async () => pipe.end(), Number.MAX_SAFE_INTEGER)
+      teardown(() => pipe.end(), Number.MAX_SAFE_INTEGER)
     })
     this.#pipe = pipe
     pipe.once('close', () => {
-      teardown(async () => program.exit(), Number.MAX_SAFE_INTEGER)
+      teardown(() => program.exit(), Number.MAX_SAFE_INTEGER)
     })
     return pipe
   }


### PR DESCRIPTION
- Allow custom runtime
  - see test: https://github.com/holepunchto/pear/pull/415

- Use teardown for pipe end/close handler
  - note that `If the process is exited explicitly, such as by calling Bare.exit() or as the result of an uncaught exception, the beforeExit event will not be emitted.`
  - see https://github.com/holepunchto/bare/blob/main/README.md#bareonbeforeexit-code
  - see test: https://github.com/holepunchto/pear/pull/416
  => this new way ensures that teardown handlers run first before ending pipe or exiting the process