### PR TITLE
improve logger

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,7 +3,7 @@ const { isBare, isWindows } = require('which-runtime')
 const hrtime = isBare ? require('bare-hrtime') : process.hrtime
 
 class Logger {
-  constructor ({ labels, fields = '', stacks = false, level = 1, pretty = false } = {}) {
+  constructor ({ labels, fields = '', stacks = false, level, pretty = false } = {}) {
     fields = this._parseFields(fields)
     this._labels = new Set(this._parseLabels(labels))
     this._labels.add('internal')
@@ -93,7 +93,7 @@ class Logger {
   }
 
   _parseLevel (level) {
-    if (typeof level !== 'string') return level
+    if (typeof level === 'number') return level
     level = level.toUpperCase()
     if (level === 'OFF' || level === '0') return 0
     if (level === 'ERR' || level === 'ERROR' || level === '1') return 1


### PR DESCRIPTION
remove default level to 1 because _parseLabels already set default level to 2
see https://github.com/holepunchto/pear/pull/429/files#diff-9c6fae252a0db7a8d112dee362cbc6b40443ab013ad80bc29b233406cf6fd546R102