### PR TITLE
Fix restart client api in Windows

### DIFF
--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -541,7 +541,7 @@ class Sidecar extends ReadyResource {
         else spawn(applingPath, opts).unref()
       } else {
         const cmd = command('run', ...runDefinition)
-        cmd.parse(cmdArgs.slice(1))
+        cmd.parse(['--detached', ...cmdArgs.slice(1)])
 
         const linkIndex = cmd?.indices?.args?.link
         const link = cmd?.args?.link

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -540,7 +540,9 @@ class Sidecar extends ReadyResource {
         if (isMac) spawn('open', [applingPath.split('.app')[0] + '.app'], opts).unref()
         else spawn(applingPath, opts).unref()
       } else {
-        cmdArgs.splice(1, 0, '--detached')
+        if (!cmdArgs.includes('--detached')) {
+          cmdArgs.splice(1, 0, '--detached')
+        }
 
         const cmd = command('run', ...runDefinition)
         cmd.parse(cmdArgs.slice(1))

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -522,7 +522,7 @@ class Sidecar extends ReadyResource {
     if (platform === false) {
       const { dir, cwd, cmdArgs, env } = client.userData.state
       const appling = client.userData.state.appling
-      const opts = { cwd, env, detached: true, stdio: 'ignore' }
+      const opts = { cwd, env, detached: false, stdio: 'ignore' }
       if (!client.closed) {
         await new Promise((resolve) => {
           if (client.closed) {
@@ -540,10 +540,6 @@ class Sidecar extends ReadyResource {
         if (isMac) spawn('open', [applingPath.split('.app')[0] + '.app'], opts).unref()
         else spawn(applingPath, opts).unref()
       } else {
-        if (!cmdArgs.includes('--detach')) {
-          cmdArgs.splice(1, 0, '--detached')
-        }
-
         const cmd = command('run', ...runDefinition)
         cmd.parse(cmdArgs.slice(1))
 

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -540,8 +540,10 @@ class Sidecar extends ReadyResource {
         if (isMac) spawn('open', [applingPath.split('.app')[0] + '.app'], opts).unref()
         else spawn(applingPath, opts).unref()
       } else {
+        cmdArgs.splice(1, 0, '--detached')
+
         const cmd = command('run', ...runDefinition)
-        cmd.parse(['--detached', ...cmdArgs.slice(1)])
+        cmd.parse(cmdArgs.slice(1))
 
         const linkIndex = cmd?.indices?.args?.link
         const link = cmd?.args?.link

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -540,7 +540,7 @@ class Sidecar extends ReadyResource {
         if (isMac) spawn('open', [applingPath.split('.app')[0] + '.app'], opts).unref()
         else spawn(applingPath, opts).unref()
       } else {
-        if (!cmdArgs.includes('--detached')) {
+        if (!cmdArgs.includes('--detach')) {
           cmdArgs.splice(1, 0, '--detached')
         }
 


### PR DESCRIPTION
Restart api does not work well in Windows
- `Pear.restart({ platform: true })` works
- `Pear.restart({ platform: false })` does not work 

test Restart-Client in doctor => should work in all OS linux/mac/windows





