### PR TITLE
expose setBadgeCount to Pear API

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1487,6 +1487,7 @@ class PearGUI extends ReadyResource {
     electron.ipcMain.handle('checkpoint', (evt, ...args) => this.checkpoint(...args))
     electron.ipcMain.handle('versions', (evt, ...args) => this.versions(...args))
     electron.ipcMain.handle('restart', (evt, ...args) => this.restart(...args))
+    electron.ipcMain.handle('badge', (evt, ...args) => this.badge(...args))
 
     electron.ipcMain.on('workerRun', (evt, link, args) => {
       const pipe = this.worker.run(link, args)
@@ -1518,9 +1519,6 @@ class PearGUI extends ReadyResource {
         return
       }
       pipe.write(data)
-    })
-    electron.ipcMain.on('setBadgeCount', (evt, count) => {
-      electron.app.setBadgeCount(count)
     })
   }
 
@@ -1736,6 +1734,8 @@ class PearGUI extends ReadyResource {
   reports () { return this.ipc.reports() }
 
   permit (params) { return this.ipc.permit(params) }
+
+  badge (count) { return electron.app.setBadgeCount(count) }
 }
 
 class Freelist {

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1519,6 +1519,9 @@ class PearGUI extends ReadyResource {
       }
       pipe.write(data)
     })
+    electron.ipcMain.on('setBadgeCount', (evt, count) => {
+      electron.app.setBadgeCount(count)
+    })
   }
 
   async app () {

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -45,6 +45,10 @@ module.exports = class PearGUI extends ReadyResource {
           desktopSources: (options = {}) => ipc.desktopSources(options)
         }
 
+        this.setBadgeCount = (count) => {
+          electron.ipcRenderer.send('setBadgeCount', count)
+        }
+
         const kGuiCtrl = Symbol('gui:ctrl')
 
         class Parent extends EventEmitter {

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -45,10 +45,6 @@ module.exports = class PearGUI extends ReadyResource {
           desktopSources: (options = {}) => ipc.desktopSources(options)
         }
 
-        this.setBadgeCount = (count) => {
-          electron.ipcRenderer.send('setBadgeCount', count)
-        }
-
         const kGuiCtrl = Symbol('gui:ctrl')
 
         class Parent extends EventEmitter {
@@ -268,6 +264,7 @@ class IPC {
   checkpoint (...args) { return electron.ipcRenderer.invoke('checkpoint', ...args) }
   versions (...args) { return electron.ipcRenderer.invoke('versions', ...args) }
   restart (...args) { return electron.ipcRenderer.invoke('restart', ...args) }
+  badge (...args) { return electron.ipcRenderer.invoke('badge', ...args) }
 
   messages (pattern) {
     electron.ipcRenderer.send('messages', pattern)

--- a/lib/api.js
+++ b/lib/api.js
@@ -34,7 +34,6 @@ class API {
     this.config = state.config
     this.worker = new Worker({ ref: () => this.#ref(), unref: () => this.#unref() })
     this.identity = new Identity({ reftrack: (promise) => this.#reftrack(promise), ipc: this.#ipc })
-    this.setBadgeCount = this.#ipc.setBadgeCount
     this.#teardowns = new Promise((resolve) => { this.#unloading = resolve })
     onteardown(() => this.#unload())
     this.#ipc.unref()
@@ -132,6 +131,11 @@ class API {
   }
 
   exit = (code) => program.exit(code)
+
+  badge = (count) => {
+    if (!Number.isInteger(+count)) throw new Error('argument is not an integer')
+    return this.#ipc.badge(count)
+  }
 }
 
 module.exports = API

--- a/lib/api.js
+++ b/lib/api.js
@@ -133,7 +133,7 @@ class API {
   exit = (code) => program.exit(code)
 
   badge = (count) => {
-    if (!Number.isInteger(+count)) throw new Error('argument is not an integer')
+    if (!Number.isInteger(+count)) throw new Error('argument must be an integer')
     return this.#ipc.badge(count)
   }
 }

--- a/lib/api.js
+++ b/lib/api.js
@@ -34,6 +34,7 @@ class API {
     this.config = state.config
     this.worker = new Worker({ ref: () => this.#ref(), unref: () => this.#unref() })
     this.identity = new Identity({ reftrack: (promise) => this.#reftrack(promise), ipc: this.#ipc })
+    this.setBadgeCount = this.#ipc.setBadgeCount
     this.#teardowns = new Promise((resolve) => { this.#unloading = resolve })
     onteardown(() => this.#unload())
     this.#ipc.unref()


### PR DESCRIPTION
Exposes Electron `setBadgeCount`  main process method. https://www.electronjs.org/docs/latest/api/app#appsetbadgecountcount-linux-macos

This requires operating system support and has been tested in Mac and Windows 10, but does not work for Ubuntu 22 and 24 with GNOME environment.