### PR TITLE
Ensure worker close gracefully with the same behaviours in both Terminal and Desktop apps

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1507,6 +1507,12 @@ class PearGUI extends ReadyResource {
       return evt.returnValue
     })
 
+    electron.ipcMain.on('workerPipeEnd', (evt, id) => {
+      const pipe = this.pipes.from(id)
+      if (!pipe) return
+      pipe.end()
+    })
+
     electron.ipcMain.on('workerPipeClose', (evt, id) => {
       const pipe = this.pipes.from(id)
       if (!pipe) return

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1490,7 +1490,6 @@ class PearGUI extends ReadyResource {
     electron.ipcMain.handle('restart', (evt, ...args) => this.restart(...args))
     electron.ipcMain.handle('badge', (evt, ...args) => this.badge(...args))
 
-
     electron.ipcMain.on('workerRun', (evt, link, args) => {
       const pipe = this.worker.run(link, args)
       const id = this.pipes.alloc(pipe)
@@ -1507,13 +1506,13 @@ class PearGUI extends ReadyResource {
       evt.returnValue = this.pipes.nextId()
       return evt.returnValue
     })
-    
+
     electron.ipcMain.once('workerPipeClose', (evt, id) => {
       const pipe = this.pipes.from(id)
       if (!pipe) return
       pipe.destroy()
     })
-    
+
     electron.ipcMain.on('workerPipeWrite', (evt, id, data) => {
       const pipe = this.pipes.from(id)
       if (!pipe) {

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1515,7 +1515,7 @@ class PearGUI extends ReadyResource {
       }
       pipe.write(data)
     })
-    electron.ipcMain.on('workerPipeClose', (evt, id) => {
+    electron.ipcMain.once('workerPipeClose', (evt, id) => {
       const pipe = this.pipes.from(id)
       if (!pipe) return
       pipe.destroy()

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1507,7 +1507,7 @@ class PearGUI extends ReadyResource {
       return evt.returnValue
     })
 
-    electron.ipcMain.once('workerPipeClose', (evt, id) => {
+    electron.ipcMain.on('workerPipeClose', (evt, id) => {
       const pipe = this.pipes.from(id)
       if (!pipe) return
       pipe.destroy()

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1498,13 +1498,13 @@ class PearGUI extends ReadyResource {
     electron.ipcMain.on('workerRun', (evt, link, args) => {
       const pipe = this.worker.run(link, args)
       const id = this.pipes.alloc(pipe)
-      pipe.on('data', (data) => { evt.reply('workerPipeData', data) })
-      pipe.on('error', (err) => { evt.reply('workerPipeError', err.stack) })
-      pipe.on('end', () => { evt.reply('workerPipeClose') })
       pipe.on('close', () => {
         this.pipes.free(id)
         evt.reply('workerPipeClose')
       })
+      pipe.on('data', (data) => { evt.reply('workerPipeData', data) })
+      pipe.on('end', () => { evt.reply('workerPipeClose') })
+      pipe.on('error', (err) => { evt.reply('workerPipeError', err.stack) })
     })
 
     electron.ipcMain.on('workerPipeWrite', (evt, id, data) => {

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -310,9 +310,6 @@ class IPC {
         cb()
       }
     })
-    stream.on('end', () => {
-      electron.ipcRenderer.send('workerPipeClose', id)
-    })
     stream.once('close', () => {
       electron.ipcRenderer.send('workerPipeClose', id)
     })

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -304,7 +304,7 @@ class IPC {
         cb()
       },
       final (cb) {
-        stream.push(null)
+        electron.ipcRenderer.send('workerPipeEnd', id)
         cb()
       }
     })

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -295,9 +295,9 @@ class IPC {
     return stream
   }
 
-  workerRun (link) {
+  workerRun (link, args) {
     const id = electron.ipcRenderer.sendSync('workerPipeId')
-    electron.ipcRenderer.send('workerRun', link)
+    electron.ipcRenderer.send('workerRun', link, args)
     const stream = new streamx.Duplex({
       write (data, cb) {
         electron.ipcRenderer.send('workerPipeWrite', id, data)

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -302,6 +302,10 @@ class IPC {
       write (data, cb) {
         electron.ipcRenderer.send('workerPipeWrite', id, data)
         cb()
+      },
+      final (cb) {
+        stream.push(null)
+        cb()
       }
     })
     electron.ipcRenderer.on('workerPipeError', (e, stack) => {
@@ -314,7 +318,7 @@ class IPC {
 
     electron.ipcRenderer.on('workerPipeData', (e, data) => { stream.push(data) })
 
-    stream.on('finish', () => {
+    stream.on('end', () => {
       electron.ipcRenderer.send('workerPipeClose', id)
     })
 

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -311,7 +311,8 @@ class IPC {
     electron.ipcRenderer.on('workerPipeError', (e, stack) => {
       stream.emit('error', new Error('Worker PipeError (from electron-main): ' + stack))
     })
-    electron.ipcRenderer.once('workerPipeClose', () => { stream.destroy() })
+    electron.ipcRenderer.on('workerPipeEnd', () => { stream.end() })
+    electron.ipcRenderer.on('workerPipeClose', () => { stream.destroy() })
     stream.once('close', () => {
       electron.ipcRenderer.send('workerPipeClose', id)
     })

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -322,7 +322,7 @@ class IPC {
       stream.emit('error', new Error('Worker PipeError (from electron-main): ' + stack))
     })
     electron.ipcRenderer.on('workerPipeClose', () => { stream.destroy() })
-    
+
     return stream
   }
 

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -313,6 +313,11 @@ class IPC {
     })
 
     electron.ipcRenderer.on('workerPipeData', (e, data) => { stream.push(data) })
+
+    stream.on('finish', () => {
+      electron.ipcRenderer.send('workerPipeClose', id)
+    })
+
     return stream
   }
 

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -311,8 +311,8 @@ class IPC {
     electron.ipcRenderer.on('workerPipeError', (e, stack) => {
       stream.emit('error', new Error('Worker PipeError (from electron-main): ' + stack))
     })
-    electron.ipcRenderer.on('workerPipeEnd', () => { stream.end() })
     electron.ipcRenderer.on('workerPipeClose', () => { stream.destroy() })
+    electron.ipcRenderer.on('workerPipeEnd', () => { stream.end() })
     stream.once('close', () => {
       electron.ipcRenderer.send('workerPipeClose', id)
     })

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -321,7 +321,7 @@ class IPC {
     electron.ipcRenderer.on('workerPipeError', (e, stack) => {
       stream.emit('error', new Error('Worker PipeError (from electron-main): ' + stack))
     })
-    electron.ipcRenderer.on('workerPipeClose', () => { stream.destroy() })
+    electron.ipcRenderer.once('workerPipeClose', () => { stream.destroy() })
 
     return stream
   }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -55,7 +55,8 @@ class Worker {
     const pipe = sp.stdio[3]
     pipe.on('error', (err) => {
       if (pipe._readableState.ended && err.code === 'ENOTCONN') {
-        console.warn('Warning: ', err)
+        // this might happen during pipe destruction, ignore it since the pipe is closing soon,
+        // otherwise the main process will crash
       } else {
         throw err
       }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -54,7 +54,10 @@ class Worker {
     })
     const pipe = sp.stdio[3]
     pipe.on('end', () => {
-      if (pipe.ended === false) pipe.end()
+      pipe.destroy()
+    })
+    pipe.on('close', () => {
+      pipe.destroy()
     })
     return pipe
   }
@@ -69,10 +72,10 @@ class Worker {
       return null
     }
     const pipe = new Pipe(fd)
-    pipe.on('end', () => {
-      teardown(() => pipe.end(), Number.MAX_SAFE_INTEGER)
-    })
     this.#pipe = pipe
+    pipe.on('end', () => {
+      teardown(() => pipe.destroy(), Number.MAX_SAFE_INTEGER)
+    })
     pipe.once('close', () => {
       teardown(() => program.exit(), Number.MAX_SAFE_INTEGER)
     })

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -54,7 +54,8 @@ class Worker {
     })
     const pipe = sp.stdio[3]
     pipe.on('end', () => {
-      pipe.destroy()
+      // should not call pipe.end() here because stream might be closed already when worker calls pipe.destroy()
+      pipe.destroy() 
     })
     pipe.on('close', () => {
       pipe.destroy()

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -77,7 +77,7 @@ class Worker {
     const pipe = new Pipe(fd)
     this.#pipe = pipe
     pipe.on('end', () => {
-      teardown(() => pipe.destroy(), Number.MAX_SAFE_INTEGER)
+      teardown(() => pipe.end(), Number.MAX_SAFE_INTEGER)
     })
     pipe.once('close', () => {
       teardown(() => program.exit(), Number.MAX_SAFE_INTEGER)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -54,12 +54,9 @@ class Worker {
     })
     const pipe = sp.stdio[3]
     pipe.on('error', (err) => {
-      if (pipe._readableState.ended && err.code === 'ENOTCONN') {
-        // this might happen during pipe destruction, ignore it since the pipe is closing soon,
-        // otherwise the main process will crash
-      } else {
-        throw err
-      }
+      if (err.code !== 'ENOTCONN') throw err
+      // 'ENOTCONN' might happen during pipe destruction, ignore it since the pipe is closing soon,
+      // otherwise the main process will crash
     })
     pipe.on('end', () => pipe.end())
     return pipe

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -53,10 +53,12 @@ class Worker {
       this.#unref()
     })
     const pipe = sp.stdio[3]
-    pipe.on('error', () => {
-      // silent all errors here to avoid crashing the main process
-      // users can listen to 'error' event for custom error handling
-    })
+    pipe.pid = sp.pid
+    const pipeEmit = pipe.emit
+    pipe.emit = function (event, ...args) {
+      if (event === 'error' && args[0]?.code === 'ENOTCONN') return false
+      return pipeEmit.apply(this, [event, ...args])
+    }
     pipe.on('end', () => pipe.end())
     return pipe
   }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -62,7 +62,6 @@ class Worker {
       }
     })
     pipe.on('end', () => pipe.end())
-    pipe.on('close', () => pipe.destroy())
     return pipe
   }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -55,7 +55,8 @@ class Worker {
     const pipe = sp.stdio[3]
     pipe.on('error', (err) => {
       if (pipe._readableState.ended && err.code === 'ENOTCONN') {
-
+        console.warn('Warning: ', err)
+        return
       } else {
         throw err
       }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -55,7 +55,7 @@ class Worker {
     const pipe = sp.stdio[3]
     pipe.on('error', (err) => {
       if (pipe._readableState.ended && err.code === 'ENOTCONN') {
-        return
+
       } else {
         throw err
       }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -54,9 +54,8 @@ class Worker {
     })
     const pipe = sp.stdio[3]
     pipe.on('error', (err) => {
-      if (err.code !== 'ENOTCONN') throw err
-      // 'ENOTCONN' might happen during pipe destruction, ignore it since the pipe is closing soon,
-      // otherwise the main process will crash
+      // silent all errors here to avoid crashing the main process
+      // users can listen to 'error' event for custom error handling
     })
     pipe.on('end', () => pipe.end())
     return pipe

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -53,13 +53,15 @@ class Worker {
       this.#unref()
     })
     const pipe = sp.stdio[3]
-    pipe.on('end', () => {
-      // should not call pipe.end() here because stream might be closed already when worker calls pipe.destroy()
-      pipe.destroy()
+    pipe.on('error', (err) => {
+      if (pipe._readableState.ended && err.code === 'ENOTCONN') {
+        return
+      } else {
+        throw err
+      }
     })
-    pipe.on('close', () => {
-      pipe.destroy()
-    })
+    pipe.on('end', () => pipe.end())
+    pipe.on('close', () => pipe.destroy())
     return pipe
   }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -56,7 +56,6 @@ class Worker {
     pipe.on('error', (err) => {
       if (pipe._readableState.ended && err.code === 'ENOTCONN') {
         console.warn('Warning: ', err)
-        return
       } else {
         throw err
       }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -55,7 +55,7 @@ class Worker {
     const pipe = sp.stdio[3]
     pipe.on('end', () => {
       // should not call pipe.end() here because stream might be closed already when worker calls pipe.destroy()
-      pipe.destroy() 
+      pipe.destroy()
     })
     pipe.on('close', () => {
       pipe.destroy()

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -76,10 +76,10 @@ class Worker {
       return null
     }
     const pipe = new Pipe(fd)
-    this.#pipe = pipe
     pipe.on('end', () => {
       teardown(() => pipe.end(), Number.MAX_SAFE_INTEGER)
     })
+    this.#pipe = pipe
     pipe.once('close', () => {
       teardown(() => program.exit(), Number.MAX_SAFE_INTEGER)
     })

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -53,7 +53,7 @@ class Worker {
       this.#unref()
     })
     const pipe = sp.stdio[3]
-    pipe.on('error', (err) => {
+    pipe.on('error', () => {
       // silent all errors here to avoid crashing the main process
       // users can listen to 'error' event for custom error handling
     })

--- a/test/03-worker.test.js
+++ b/test/03-worker.test.js
@@ -8,6 +8,13 @@ const helloWorld = path.join(Helper.localDir, 'test', 'fixtures', 'hello-world')
 const printArgs = path.join(Helper.localDir, 'test', 'fixtures', 'print-args')
 const workerRunner = path.join(Helper.localDir, 'test', 'fixtures', 'worker-runner')
 
+const workerParent = path.join(Helper.localDir, 'test', 'fixtures', 'worker-parent')
+const workerChild = path.join(Helper.localDir, 'test', 'fixtures', 'worker-child')
+const workerEndFromChild = path.join(Helper.localDir, 'test', 'fixtures', 'worker-end-from-child')
+const workerDestroyFromChild = path.join(Helper.localDir, 'test', 'fixtures', 'worker-destroy-from-child')
+const workerEndFromParent = path.join(Helper.localDir, 'test', 'fixtures', 'worker-end-from-parent')
+const workerDestroyFromParent = path.join(Helper.localDir, 'test', 'fixtures', 'worker-destroy-from-parent')
+
 test('worker pipe', async function ({ is, plan, teardown }) {
   plan(1)
   const helper = new Helper()
@@ -98,4 +105,52 @@ test('worker should run as a link in a terminal app', async function ({ is, plan
   is(response, 'hello world', 'worker should send expected response')
 
   await Helper.untilClose(pipe)
+})
+
+//
+// test worker exit gracefully for terminal app
+//
+
+test('[terminal] worker exit when child calls pipe.end()', async function () {
+  const { pipe } = await Helper.run({ link: workerParent, args: [workerEndFromChild] })
+  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
+})
+
+test('[terminal] worker exit when child calls pipe.destroy()', async function () {
+  const { pipe } = await Helper.run({ link: workerParent, args: [workerDestroyFromChild] })
+  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
+})
+
+test.skip('[terminal] worker exit when parent calls pipe.end()', async function () {
+  const { pipe } = await Helper.run({ link: workerEndFromParent, args: [workerChild] })
+  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
+})
+
+test.skip('[terminal] worker exit when parent calls pipe.destroy()', async function () {
+  const { pipe } = await Helper.run({ link: workerDestroyFromParent, args: [workerChild] })
+  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
+})
+
+//
+// test worker exit gracefully for desktop app
+//
+
+test.skip('[desktop] worker exit when child calls pipe.end()', async function () {
+
+})
+
+test.skip('[desktop] worker exit when child calls pipe.destroy()', async function () {
+
+})
+
+test.skip('[desktop] worker exit when parent calls pipe.end()', async function () {
+
+})
+
+test.skip('[desktop] worker exit when parent calls pipe.destroy()', async function () {
+
 })

--- a/test/03-worker.test.js
+++ b/test/03-worker.test.js
@@ -136,8 +136,9 @@ test('[terminal] worker exit when parent calls pipe.destroy()', async function (
 // test worker exit gracefully for desktop app
 //
 
-test.skip('[desktop] worker exit when child calls pipe.end()', async function () {
-
+test('[desktop] worker exit when child calls pipe.end()', async function () {
+  const { pipe } = await Helper.run({ link: workerParentDesktop, args: [workerChild] })
+  await Helper.untilClose(pipe)
 })
 
 test.skip('[desktop] worker exit when child calls pipe.destroy()', async function () {

--- a/test/03-worker.test.js
+++ b/test/03-worker.test.js
@@ -14,7 +14,10 @@ const workerEndFromChild = path.join(Helper.localDir, 'test', 'fixtures', 'worke
 const workerDestroyFromChild = path.join(Helper.localDir, 'test', 'fixtures', 'worker-destroy-from-child')
 const workerEndFromParent = path.join(Helper.localDir, 'test', 'fixtures', 'worker-end-from-parent')
 const workerDestroyFromParent = path.join(Helper.localDir, 'test', 'fixtures', 'worker-destroy-from-parent')
+
 const workerParentDesktop = path.join(Helper.localDir, 'test', 'fixtures', 'worker-parent-desktop')
+const workerEndFromParentDesktop = path.join(Helper.localDir, 'test', 'fixtures', 'worker-end-from-parent-desktop')
+const workerDestroyFromParentDesktop = path.join(Helper.localDir, 'test', 'fixtures', 'worker-destroy-from-parent-desktop')
 
 test('worker pipe', async function ({ is, plan, teardown }) {
   plan(1)
@@ -137,18 +140,21 @@ test('[terminal] worker exit when parent calls pipe.destroy()', async function (
 //
 
 test('[desktop] worker exit when child calls pipe.end()', async function () {
-  const { pipe } = await Helper.run({ link: workerParentDesktop, args: [workerChild] })
+  const { pipe } = await Helper.run({ link: workerParentDesktop, args: [workerEndFromChild] })
   await Helper.untilClose(pipe)
 })
 
-test.skip('[desktop] worker exit when child calls pipe.destroy()', async function () {
-
+test('[desktop] worker exit when child calls pipe.destroy()', async function () {
+  const { pipe } = await Helper.run({ link: workerParentDesktop, args: [workerDestroyFromChild] })
+  await Helper.untilClose(pipe)
 })
 
-test.skip('[desktop] worker exit when parent calls pipe.end()', async function () {
-
+test('[desktop] worker exit when parent calls pipe.end()', async function () {
+  const { pipe } = await Helper.run({ link: workerEndFromParentDesktop, args: [workerChild] })
+  await Helper.untilClose(pipe)
 })
 
-test.skip('[desktop] worker exit when parent calls pipe.destroy()', async function () {
-
+test('[desktop] worker exit when parent calls pipe.destroy()', async function () {
+  const { pipe } = await Helper.run({ link: workerDestroyFromParentDesktop, args: [workerChild] })
+  await Helper.untilClose(pipe)
 })

--- a/test/03-worker.test.js
+++ b/test/03-worker.test.js
@@ -117,22 +117,22 @@ test('worker should run as a link in a terminal app', async function ({ is, plan
 
 test('[terminal] worker exit when child calls pipe.end()', async function () {
   const { pipe } = await Helper.run({ link: workerParent, args: [workerEndFromChild] })
-  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
 })
 
 test('[terminal] worker exit when child calls pipe.destroy()', async function () {
   const { pipe } = await Helper.run({ link: workerParent, args: [workerDestroyFromChild] })
-  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
 })
 
 test('[terminal] worker exit when parent calls pipe.end()', async function () {
   const { pipe } = await Helper.run({ link: workerEndFromParent, args: [workerChild] })
-  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
 })
 
 test('[terminal] worker exit when parent calls pipe.destroy()', async function () {
   const { pipe } = await Helper.run({ link: workerDestroyFromParent, args: [workerChild] })
-  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
 })
 
 //
@@ -141,20 +141,20 @@ test('[terminal] worker exit when parent calls pipe.destroy()', async function (
 
 test('[desktop] worker exit when child calls pipe.end()', async function () {
   const { pipe } = await Helper.run({ link: workerParentDesktop, args: [workerEndFromChild] })
-  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
 })
 
 test('[desktop] worker exit when child calls pipe.destroy()', async function () {
   const { pipe } = await Helper.run({ link: workerParentDesktop, args: [workerDestroyFromChild] })
-  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
 })
 
 test('[desktop] worker exit when parent calls pipe.end()', async function () {
   const { pipe } = await Helper.run({ link: workerEndFromParentDesktop, args: [workerChild] })
-  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
 })
 
 test('[desktop] worker exit when parent calls pipe.destroy()', async function () {
   const { pipe } = await Helper.run({ link: workerDestroyFromParentDesktop, args: [workerChild] })
-  await Helper.untilClose(pipe)
+  await Helper.untilWorkerExit(pipe)
 })

--- a/test/03-worker.test.js
+++ b/test/03-worker.test.js
@@ -14,6 +14,7 @@ const workerEndFromChild = path.join(Helper.localDir, 'test', 'fixtures', 'worke
 const workerDestroyFromChild = path.join(Helper.localDir, 'test', 'fixtures', 'worker-destroy-from-child')
 const workerEndFromParent = path.join(Helper.localDir, 'test', 'fixtures', 'worker-end-from-parent')
 const workerDestroyFromParent = path.join(Helper.localDir, 'test', 'fixtures', 'worker-destroy-from-parent')
+const workerParentDesktop = path.join(Helper.localDir, 'test', 'fixtures', 'worker-parent-desktop')
 
 test('worker pipe', async function ({ is, plan, teardown }) {
   plan(1)
@@ -114,25 +115,21 @@ test('worker should run as a link in a terminal app', async function ({ is, plan
 test('[terminal] worker exit when child calls pipe.end()', async function () {
   const { pipe } = await Helper.run({ link: workerParent, args: [workerEndFromChild] })
   await Helper.untilClose(pipe)
-  await Helper.untilWorkerExit(pipe)
 })
 
 test('[terminal] worker exit when child calls pipe.destroy()', async function () {
   const { pipe } = await Helper.run({ link: workerParent, args: [workerDestroyFromChild] })
   await Helper.untilClose(pipe)
-  await Helper.untilWorkerExit(pipe)
 })
 
 test('[terminal] worker exit when parent calls pipe.end()', async function () {
   const { pipe } = await Helper.run({ link: workerEndFromParent, args: [workerChild] })
   await Helper.untilClose(pipe)
-  await Helper.untilWorkerExit(pipe)
 })
 
 test('[terminal] worker exit when parent calls pipe.destroy()', async function () {
   const { pipe } = await Helper.run({ link: workerDestroyFromParent, args: [workerChild] })
   await Helper.untilClose(pipe)
-  await Helper.untilWorkerExit(pipe)
 })
 
 //

--- a/test/03-worker.test.js
+++ b/test/03-worker.test.js
@@ -123,13 +123,13 @@ test('[terminal] worker exit when child calls pipe.destroy()', async function ()
   await Helper.untilWorkerExit(pipe)
 })
 
-test.skip('[terminal] worker exit when parent calls pipe.end()', async function () {
+test('[terminal] worker exit when parent calls pipe.end()', async function () {
   const { pipe } = await Helper.run({ link: workerEndFromParent, args: [workerChild] })
   await Helper.untilClose(pipe)
   await Helper.untilWorkerExit(pipe)
 })
 
-test.skip('[terminal] worker exit when parent calls pipe.destroy()', async function () {
+test('[terminal] worker exit when parent calls pipe.destroy()', async function () {
   const { pipe } = await Helper.run({ link: workerDestroyFromParent, args: [workerChild] })
   await Helper.untilClose(pipe)
   await Helper.untilWorkerExit(pipe)

--- a/test/fixtures/worker-child/index.js
+++ b/test/fixtures/worker-child/index.js
@@ -1,0 +1,2 @@
+const pipe = Pear.worker.pipe()
+pipe.resume()

--- a/test/fixtures/worker-child/package.json
+++ b/test/fixtures/worker-child/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "worker-child",
+  "main": "index.js",
+  "pear": {}
+}

--- a/test/fixtures/worker-child/package.json
+++ b/test/fixtures/worker-child/package.json
@@ -1,5 +1,6 @@
 {
   "name": "worker-child",
   "main": "index.js",
+  "type": "module",
   "pear": {}
 }

--- a/test/fixtures/worker-destroy-from-child/index.js
+++ b/test/fixtures/worker-destroy-from-child/index.js
@@ -1,0 +1,4 @@
+const pipe = Pear.worker.pipe()
+pipe.resume()
+await new Promise((resolve) => setTimeout(resolve, 1000))
+pipe.destroy()

--- a/test/fixtures/worker-destroy-from-child/package.json
+++ b/test/fixtures/worker-destroy-from-child/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "worker-destroy-from-child",
+  "main": "index.js",
+  "type": "module",
+  "pear": {}
+}

--- a/test/fixtures/worker-destroy-from-parent-desktop/app.js
+++ b/test/fixtures/worker-destroy-from-parent-desktop/app.js
@@ -1,4 +1,3 @@
-const pipeIn = Pear.worker.pipe()
 const link = Pear.config.args[Pear.config.args.length - 1]
 const pipe = Pear.worker.run(link)
 pipe.resume()

--- a/test/fixtures/worker-destroy-from-parent-desktop/app.js
+++ b/test/fixtures/worker-destroy-from-parent-desktop/app.js
@@ -1,0 +1,24 @@
+const pipeIn = Pear.worker.pipe()
+const link = Pear.config.args[Pear.config.args.length - 1]
+const pipe = Pear.worker.run(link)
+pipe.resume()
+await new Promise((resolve) => setTimeout(resolve, 1000))
+pipe.destroy()
+await untilExit(pipe)
+Pear.Window.self.close()
+
+async function untilExit (pipe, timeout = 5000) {
+  const start = Date.now()
+  while (isRunning(pipe)) {
+    if (Date.now() - start > timeout) throw new Error('timed out')
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+}
+
+function isRunning (pipe) {
+  try {
+    return process.kill(pipe.pid, 0)
+  } catch (err) {
+    return err.code === 'EPERM'
+  }
+}

--- a/test/fixtures/worker-destroy-from-parent-desktop/index.html
+++ b/test/fixtures/worker-destroy-from-parent-desktop/index.html
@@ -1,0 +1,2 @@
+<pear-ctrl></pear-ctrl>
+<script src="./app.js" type="module"></script>

--- a/test/fixtures/worker-destroy-from-parent-desktop/package.json
+++ b/test/fixtures/worker-destroy-from-parent-desktop/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "worker-parent-desktop",
+  "main": "index.html",
+  "type": "module",
+  "pear": {}
+}

--- a/test/fixtures/worker-destroy-from-parent-desktop/package.json
+++ b/test/fixtures/worker-destroy-from-parent-desktop/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "worker-parent-desktop",
+  "name": "worker-destroy-from-parent-desktop",
   "main": "index.html",
   "type": "module",
   "pear": {}

--- a/test/fixtures/worker-destroy-from-parent/index.js
+++ b/test/fixtures/worker-destroy-from-parent/index.js
@@ -1,4 +1,5 @@
 const link = Bare.argv[Bare.argv.length - 1]
 const pipe = Pear.worker.run(link)
 pipe.resume()
+await new Promise((resolve) => setTimeout(resolve, 1000))
 pipe.destroy()

--- a/test/fixtures/worker-destroy-from-parent/index.js
+++ b/test/fixtures/worker-destroy-from-parent/index.js
@@ -3,3 +3,20 @@ const pipe = Pear.worker.run(link)
 pipe.resume()
 await new Promise((resolve) => setTimeout(resolve, 1000))
 pipe.destroy()
+await untilExit(pipe)
+
+async function untilExit (pipe, timeout = 5000) {
+  const start = Date.now()
+  while (isRunning(pipe)) {
+    if (Date.now() - start > timeout) throw new Error('timed out')
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+}
+
+function isRunning (pipe) {
+  try {
+    return process.kill(pipe.pid, 0)
+  } catch (err) {
+    return err.code === 'EPERM'
+  }
+}

--- a/test/fixtures/worker-destroy-from-parent/index.js
+++ b/test/fixtures/worker-destroy-from-parent/index.js
@@ -1,0 +1,4 @@
+const link = Bare.argv[Bare.argv.length - 1]
+const pipe = Pear.worker.run(link)
+pipe.resume()
+pipe.destroy()

--- a/test/fixtures/worker-destroy-from-parent/package.json
+++ b/test/fixtures/worker-destroy-from-parent/package.json
@@ -1,5 +1,6 @@
 {
   "name": "worker-destroy-from-parent",
   "main": "index.js",
+  "type": "module",
   "pear": {}
 }

--- a/test/fixtures/worker-destroy-from-parent/package.json
+++ b/test/fixtures/worker-destroy-from-parent/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "worker-destroy-from-parent",
+  "main": "index.js",
+  "pear": {}
+}

--- a/test/fixtures/worker-end-from-child/index.js
+++ b/test/fixtures/worker-end-from-child/index.js
@@ -1,0 +1,4 @@
+const pipe = Pear.worker.pipe()
+pipe.resume()
+await new Promise((resolve) => setTimeout(resolve, 1000))
+pipe.end()

--- a/test/fixtures/worker-end-from-child/package.json
+++ b/test/fixtures/worker-end-from-child/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "worker-end-from-child",
+  "main": "index.js",
+  "type": "module",
+  "pear": {}
+}

--- a/test/fixtures/worker-end-from-parent-desktop/app.js
+++ b/test/fixtures/worker-end-from-parent-desktop/app.js
@@ -1,4 +1,3 @@
-const pipeIn = Pear.worker.pipe()
 const link = Pear.config.args[Pear.config.args.length - 1]
 const pipe = Pear.worker.run(link)
 pipe.resume()

--- a/test/fixtures/worker-end-from-parent-desktop/app.js
+++ b/test/fixtures/worker-end-from-parent-desktop/app.js
@@ -1,0 +1,24 @@
+const pipeIn = Pear.worker.pipe()
+const link = Pear.config.args[Pear.config.args.length - 1]
+const pipe = Pear.worker.run(link)
+pipe.resume()
+await new Promise((resolve) => setTimeout(resolve, 1000))
+pipe.end()
+await untilExit(pipe)
+Pear.Window.self.close()
+
+async function untilExit (pipe, timeout = 5000) {
+  const start = Date.now()
+  while (isRunning(pipe)) {
+    if (Date.now() - start > timeout) throw new Error('timed out')
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+}
+
+function isRunning (pipe) {
+  try {
+    return process.kill(pipe.pid, 0)
+  } catch (err) {
+    return err.code === 'EPERM'
+  }
+}

--- a/test/fixtures/worker-end-from-parent-desktop/index.html
+++ b/test/fixtures/worker-end-from-parent-desktop/index.html
@@ -1,0 +1,2 @@
+<pear-ctrl></pear-ctrl>
+<script src="./app.js" type="module"></script>

--- a/test/fixtures/worker-end-from-parent-desktop/package.json
+++ b/test/fixtures/worker-end-from-parent-desktop/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "worker-parent-desktop",
+  "name": "worker-end-from-parent-desktop",
   "main": "index.html",
   "type": "module",
   "pear": {}

--- a/test/fixtures/worker-end-from-parent-desktop/package.json
+++ b/test/fixtures/worker-end-from-parent-desktop/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "worker-parent-desktop",
+  "main": "index.html",
+  "type": "module",
+  "pear": {}
+}

--- a/test/fixtures/worker-end-from-parent/index.js
+++ b/test/fixtures/worker-end-from-parent/index.js
@@ -1,0 +1,4 @@
+const link = Bare.argv[Bare.argv.length - 1]
+const pipe = Pear.worker.run(link)
+pipe.resume()
+pipe.end()

--- a/test/fixtures/worker-end-from-parent/index.js
+++ b/test/fixtures/worker-end-from-parent/index.js
@@ -1,4 +1,5 @@
 const link = Bare.argv[Bare.argv.length - 1]
 const pipe = Pear.worker.run(link)
 pipe.resume()
+await new Promise((resolve) => setTimeout(resolve, 1000))
 pipe.end()

--- a/test/fixtures/worker-end-from-parent/index.js
+++ b/test/fixtures/worker-end-from-parent/index.js
@@ -3,3 +3,20 @@ const pipe = Pear.worker.run(link)
 pipe.resume()
 await new Promise((resolve) => setTimeout(resolve, 1000))
 pipe.end()
+await untilExit(pipe)
+
+async function untilExit (pipe, timeout = 5000) {
+  const start = Date.now()
+  while (isRunning(pipe)) {
+    if (Date.now() - start > timeout) throw new Error('timed out')
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+}
+
+function isRunning (pipe) {
+  try {
+    return process.kill(pipe.pid, 0)
+  } catch (err) {
+    return err.code === 'EPERM'
+  }
+}

--- a/test/fixtures/worker-end-from-parent/package.json
+++ b/test/fixtures/worker-end-from-parent/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "worker-end-from-parent",
+  "main": "index.js",
+  "pear": {}
+}

--- a/test/fixtures/worker-end-from-parent/package.json
+++ b/test/fixtures/worker-end-from-parent/package.json
@@ -1,5 +1,6 @@
 {
   "name": "worker-end-from-parent",
   "main": "index.js",
+  "type": "module",
   "pear": {}
 }

--- a/test/fixtures/worker-parent-desktop/app.js
+++ b/test/fixtures/worker-parent-desktop/app.js
@@ -1,4 +1,3 @@
-const pipeIn = Pear.worker.pipe()
 const link = Pear.config.args[Pear.config.args.length - 1]
 const pipe = Pear.worker.run(link)
 pipe.resume()

--- a/test/fixtures/worker-parent-desktop/app.js
+++ b/test/fixtures/worker-parent-desktop/app.js
@@ -2,8 +2,6 @@ const pipeIn = Pear.worker.pipe()
 const link = Pear.config.args[Pear.config.args.length - 1]
 const pipe = Pear.worker.run(link)
 pipe.resume()
-await new Promise((resolve) => setTimeout(resolve, 1000))
-pipe.end()
 await untilExit(pipe)
 Pear.Window.self.close()
 

--- a/test/fixtures/worker-parent-desktop/app.js
+++ b/test/fixtures/worker-parent-desktop/app.js
@@ -1,0 +1,24 @@
+const pipeIn = Pear.worker.pipe()
+const link = Pear.config.args[Pear.config.args.length - 1]
+const pipe = Pear.worker.run(link)
+pipe.resume()
+await new Promise((resolve) => setTimeout(resolve, 1000))
+pipe.end()
+await untilExit(pipe)
+Pear.Window.self.close()
+
+async function untilExit (pipe, timeout = 5000) {
+  const start = Date.now()
+  while (isRunning(pipe)) {
+    if (Date.now() - start > timeout) throw new Error('timed out')
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+}
+
+function isRunning (pipe) {
+  try {
+    return process.kill(pipe.pid, 0)
+  } catch (err) {
+    return err.code === 'EPERM'
+  }
+}

--- a/test/fixtures/worker-parent-desktop/index.html
+++ b/test/fixtures/worker-parent-desktop/index.html
@@ -1,0 +1,2 @@
+<pear-ctrl></pear-ctrl>
+<script src="./app.js" type="module"></script>

--- a/test/fixtures/worker-parent-desktop/package.json
+++ b/test/fixtures/worker-parent-desktop/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "worker-parent-desktop",
+  "main": "index.html",
+  "type": "module",
+  "pear": {}
+}

--- a/test/fixtures/worker-parent/index.js
+++ b/test/fixtures/worker-parent/index.js
@@ -1,4 +1,3 @@
-
 const link = Bare.argv[Bare.argv.length - 1]
 const pipe = Pear.worker.run(link)
 pipe.resume()

--- a/test/fixtures/worker-parent/index.js
+++ b/test/fixtures/worker-parent/index.js
@@ -1,0 +1,4 @@
+
+const link = Bare.argv[Bare.argv.length - 1]
+const pipe = Pear.worker.run(link)
+pipe.resume()

--- a/test/fixtures/worker-parent/index.js
+++ b/test/fixtures/worker-parent/index.js
@@ -1,3 +1,20 @@
 const link = Bare.argv[Bare.argv.length - 1]
 const pipe = Pear.worker.run(link)
 pipe.resume()
+await untilExit(pipe)
+
+async function untilExit (pipe, timeout = 5000) {
+  const start = Date.now()
+  while (isRunning(pipe)) {
+    if (Date.now() - start > timeout) throw new Error('timed out')
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+}
+
+function isRunning (pipe) {
+  try {
+    return process.kill(pipe.pid, 0)
+  } catch (err) {
+    return err.code === 'EPERM'
+  }
+}

--- a/test/fixtures/worker-parent/package.json
+++ b/test/fixtures/worker-parent/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "worker-parent",
+  "main": "index.js",
+  "pear": {}
+}

--- a/test/fixtures/worker-parent/package.json
+++ b/test/fixtures/worker-parent/package.json
@@ -1,5 +1,6 @@
 {
   "name": "worker-parent",
   "main": "index.js",
+  "type": "module",
   "pear": {}
 }

--- a/test/helper.js
+++ b/test/helper.js
@@ -196,22 +196,6 @@ class Helper extends IPC.Client {
     return res
   }
 
-  static async isRunning (pipe) {
-    try {
-      return process.kill(pipe.pid, 0)
-    } catch (err) {
-      return err.code === 'EPERM'
-    }
-  }
-
-  static async untilWorkerExit (pipe, timeout = 5000) {
-    const start = Date.now()
-    while (await this.isRunning(pipe)) {
-      if (Date.now() - start > timeout) throw new Error('timed out')
-      await new Promise((resolve) => setTimeout(resolve, 100))
-    }
-  }
-
   static async pick (stream, ptn = {}, by = 'tag') {
     if (Array.isArray(ptn)) return this.#untils(stream, ptn, by)
     for await (const output of stream) {

--- a/test/helper.js
+++ b/test/helper.js
@@ -196,6 +196,22 @@ class Helper extends IPC.Client {
     return res
   }
 
+  static async isRunning (pipe) {
+    try {
+      return process.kill(pipe.pid, 0)
+    } catch (err) {
+      return err.code === 'EPERM'
+    }
+  }
+
+  static async untilWorkerExit (pipe, timeout = 5000) {
+    const start = Date.now()
+    while (await this.isRunning(pipe)) {
+      if (Date.now() - start > timeout) throw new Error('timed out')
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+  }
+
   static async pick (stream, ptn = {}, by = 'tag') {
     if (Array.isArray(ptn)) return this.#untils(stream, ptn, by)
     for await (const output of stream) {


### PR DESCRIPTION
# App Type
- Terminal and Desktop apps can call `Pear.Worker.run` api to start Worker process
- Parent/Worker can call `pipe.end` or `pipe.destroy`
- These scenarios should be passed, and same behaviours in Terminal and Desktop apps

# Scenarios

- Parent calls `pipe.end()` 
  - Worker receives `end` event
  - Worker receives `close` event
  - Worker is killed
  - Parent receives `end` event
  - Parent receives `close` event

- Parent calls `pipe.destroy()`
  - Worker receives `end` event
  - Worker receives `close` event
  - Worker is killed
  - Parent receives `close` event only (no `end` event)

- Worker calls `pipe.end()`
  - Worker receives `end` event
  - Worker receives `close` event
  - Worker is killed
  - Parent receives `end` event
  - Parent receives `close` event

- Worker calls `pipe.end()`
  - Worker receives `close` event only (no `end` event)
  - Worker is killed
  - Parent receives `end` event
  - Parent receives `close` event

# How to test


Sample Parent code
```
const pipe = Pear.worker.run('../worker-code')
pipe.on('data', (data) => {
  console.log(data.toString())
})
pipe.on('end', () => {
  console.log('end')
})
pipe.on('close', () => {
  console.log('close')
})
pipe.write('hello')
await new Promise((resolve) => setTimeout(resolve, 2000))
// pipe.end()
// pipe.destroy()
await new Promise((resolve) => setTimeout(resolve, 20000))
```

Sample Worker code
```
import fs from 'bare-fs'
const pipe = Pear.worker.pipe()
pipe.on('data', (data) => {
  pipe.write('world')
  fs.writeFileSync('/tmp/test-data', data.toString())
})
pipe.on('end', () => {
  fs.writeFileSync('/tmp/test-end', 'end')
})
pipe.on('close', () => {
  fs.writeFileSync('/tmp/test-close', 'close')
})
await new Promise((resolve) => setTimeout(resolve, 2000))
// pipe.end()
// pipe.destroy()
```

- Run `pear.dev run -d parent-code-dir`
- Uncomment pipe.end() or pipe.destroy()
- Make sure Worker process is killed
- Check `/tmp/test-data`, `/tmp/test-end`, `/tmp/test-close` for worker events

# Add tests
![image](https://github.com/user-attachments/assets/244b251f-a984-488d-b185-5b697ef34058)
