### PR TITLE
fixed terminal app without teardown exit

### DIFF
--- a/lib/teardown.js
+++ b/lib/teardown.js
@@ -6,8 +6,6 @@ module.exports = teardown
 
 const handlers = []
 
-const forceExit = true // Bare.exit after teardown loop
-
 let exiting = false
 
 const sigint = new Signal('SIGINT')
@@ -45,12 +43,8 @@ function onexit () {
   loop()
 
   function loop () {
-    if (!order.length) return done()
+    if (!order.length) return
     Promise.allSettled(order.pop().map(run)).then(loop, loop)
-  }
-
-  function done () {
-    if (forceExit) Bare.exit()
   }
 }
 

--- a/test/fixtures/worker-teardown-os-kill/index.js
+++ b/test/fixtures/worker-teardown-os-kill/index.js
@@ -5,4 +5,5 @@ Pear.teardown(async () => {
   await new Promise((resolve) => {
     pipe.write('teardown', resolve)
   })
+  pipe.end()
 })


### PR DESCRIPTION
This PR fixes lifecycle issue for Pear terminal apps without teardown.
Pear terminal apps without Pear.teardown provoked Bare.exit before `beforeExit`, `SIGINT` or `SIGTER` hooks were executed. This PR removes Bare.exit and forces Pear terminal apps to terminate all handles in order to terminate the app.