### PR TITLE
improve worker desktop

### DIFF
--- a/run.js
+++ b/run.js
@@ -147,7 +147,7 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
 
     const worker = new Worker()
     const pipe = worker.pipe()
-    if (pipe) {
+    if (pipe !== null) {
       pipe.on('end', () => child.kill())
       pipe.on('close', () => child.kill())
     }
@@ -155,6 +155,9 @@ module.exports = async function run ({ ipc, args, cmdArgs, link, storage, detach
     child.once('exit', (code) => {
       stream.push({ tag: 'exit', data: { code } })
       ipc.close()
+      if (pipe !== null) {
+        pipe.end()
+      }
     })
     if (!detach) {
       child.stdout.on('data', (data) => { stream.push({ tag: 'stdout', data }) })


### PR DESCRIPTION
# Issue
- Run `./pear.dev run -d ./examples/desktop`
- Then in browser console, run `Pear.worker.run('pear://doctor')`
- Now, 
  - case 1: if `Ctrl C` => both desktop apps closed
  - case 2: if we manual close examples/desktop app, doctor does not close

# Summary
This PR handles the case 2 to close all child workers when the parent closes