### PR TITLE
fixed worker args

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -9,6 +9,7 @@ const Pipe = isBare
   : class Pipe extends require('net').Socket { constructor (fd) { super({ fd }) } }
 const constants = require('../constants')
 const rundef = require('../def/run')
+const shell = require('../shell')
 const noop = Function.prototype
 const program = global.Bare || global.process
 
@@ -26,7 +27,8 @@ class Worker {
 
   #args (link) {
     const parser = command('pear', command('run', ...rundef))
-    const argv = ['run', '--trusted', ...program.argv.slice(program.argv.indexOf('run') + 1)]
+    const cmdIdx = shell(program.argv.slice(1), { sync: true }).indices.args.cmd
+    const argv = ['run', '--trusted', ...program.argv.slice(1).slice(cmdIdx + 1)]
     const cmd = parser.parse(argv, { sync: true })
     const args = argv.map((arg) => arg === cmd.args.link ? link : arg)
     if (cmd.indices.rest > 0) args.splice(cmd.indices.rest)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -28,7 +28,8 @@ class Worker {
   #args (link) {
     const parser = command('pear', command('run', ...rundef))
     const cmdIdx = shell(program.argv.slice(1), { sync: true }).indices.args.cmd
-    const argv = ['run', '--trusted', ...program.argv.slice(1).slice(cmdIdx + 1)]
+    const slice = program.argv.slice(1)
+    const argv = ['run', '--trusted', ...slice.slice(cmdIdx + 1)]
     const cmd = parser.parse(argv, { sync: true })
     const args = argv.map((arg) => arg === cmd.args.link ? link : arg)
     if (cmd.indices.rest > 0) args.splice(cmd.indices.rest)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -28,9 +28,9 @@ class Worker {
   #args (link) {
     const parser = command('pear', command('run', ...rundef))
     const sliced = program.argv.slice(1)
-    const cmdIdx = shell(sliced, { sync: true }).indices.args.cmd
+    const cmdIdx = shell(sliced).indices.args.cmd
     const argv = ['run', '--trusted', ...sliced.slice(cmdIdx + 1)]
-    const cmd = parser.parse(argv, { sync: true })
+    const cmd = parser.parse(argv)
     const args = argv.map((arg) => arg === cmd.args.link ? link : arg)
     if (cmd.indices.rest > 0) args.splice(cmd.indices.rest)
     let linksIndex = cmd.indices.flags.links

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -26,7 +26,7 @@ class Worker {
 
   #args (link) {
     const parser = command('pear', command('run', ...rundef))
-    const argv = ['run', '--trusted', ...program.argv.slice(2)]
+    const argv = ['run', '--trusted', ...program.argv.slice(program.argv.indexOf('run') + 1)]
     const cmd = parser.parse(argv, { sync: true })
     const args = argv.map((arg) => arg === cmd.args.link ? link : arg)
     if (cmd.indices.rest > 0) args.splice(cmd.indices.rest)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -28,8 +28,8 @@ class Worker {
   #args (link) {
     const parser = command('pear', command('run', ...rundef))
     const cmdIdx = shell(program.argv.slice(1), { sync: true }).indices.args.cmd
-    const slice = program.argv.slice(1)
-    const argv = ['run', '--trusted', ...slice.slice(cmdIdx + 1)]
+    const sliced = program.argv.slice(1)
+    const argv = ['run', '--trusted', ...sliced.slice(cmdIdx + 1)]
     const cmd = parser.parse(argv, { sync: true })
     const args = argv.map((arg) => arg === cmd.args.link ? link : arg)
     if (cmd.indices.rest > 0) args.splice(cmd.indices.rest)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -27,8 +27,8 @@ class Worker {
 
   #args (link) {
     const parser = command('pear', command('run', ...rundef))
-    const cmdIdx = shell(program.argv.slice(1), { sync: true }).indices.args.cmd
     const sliced = program.argv.slice(1)
+    const cmdIdx = shell(sliced, { sync: true }).indices.args.cmd
     const argv = ['run', '--trusted', ...sliced.slice(cmdIdx + 1)]
     const cmd = parser.parse(argv, { sync: true })
     const args = argv.map((arg) => arg === cmd.args.link ? link : arg)


### PR DESCRIPTION
This PR fixes worker arguments when `pear` parent command includes flags, ie `pear --log run pear://key --flag`