### PR TITLE
added user agent to configuration

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -366,8 +366,6 @@ class ContextMenu {
   }
 }
 
-electron.app.userAgentFallback = 'Pear Platform'
-
 class App {
   menu = null
   sidecar = null
@@ -980,9 +978,7 @@ class Window extends GuiCtrl {
       this.state = await this.appkin
       this.appkin = null
     }
-    const ua = `Pear ${this.state.id}`
     const session = electron.session.fromPartition(`persist:${this.sessname || (this.state.key ? hypercoreid.encode(this.state.key) : this.state.dir)}`)
-    session.setUserAgent(ua)
 
     const { show = true } = { show: (options.show || options.window?.show) }
     const { height = this.constructor.height, width = this.constructor.width } = options
@@ -1077,6 +1073,13 @@ class Window extends GuiCtrl {
     }
     const onBeforeSendHeaders = (details, next) => {
       details.requestHeaders.Pragma = details.requestHeaders['Cache-Control'] = 'no-cache'
+      const sidecarURL = new URL(this.sidecar)
+      const requestURL = new URL(details.url)
+      if (requestURL.host === sidecarURL.host) {
+        details.requestHeaders['User-Agent'] = `Pear ${this.state.id}`
+      } else if (this.state.userAgent) {
+        details.requestHeaders['User-Agent'] = this.state.userAgent
+      }
       next({ requestHeaders: details.requestHeaders })
     }
 
@@ -1284,9 +1287,7 @@ class View extends GuiCtrl {
       this.state = await this.appkin
       this.appkin = null
     }
-    const ua = `Pear ${this.state.id}`
     const session = electron.session.fromPartition(`persist:${this.sessname || (this.state.key ? hypercoreid.encode(this.state.key) : this.state.dir)}`)
-    session.setUserAgent(ua)
 
     this.view = new BrowserView({
       ...(options?.view || options),

--- a/state.js
+++ b/state.js
@@ -43,6 +43,7 @@ module.exports = class State {
     state.name = pkg?.pear?.name || pkg?.holepunch?.name || pkg?.name || null
     state.type = pkg?.pear?.type || (/\.(c|m)?js$/.test(state.main) ? 'terminal' : 'desktop')
     state.links = pkg?.pear?.links || null
+    state.userAgent = pkg?.pear?.userAgent
     if (overrides.links) {
       const links = overrides.links.split(',').reduce((links, kv) => {
         const [key, value] = kv.split('=')


### PR DESCRIPTION
This PR sets a custom User-Agent header to Electron fetch request if the request host is the the sidecar host and a value is provided in the `userAgent` field of the Pear application configuration