### PR TITLE
improve gui close to wait for all pipes to close or error (instead of rejecting immediately if one pipe has error)

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -652,7 +652,7 @@ class App {
       return ctrl.unloader.then(closed, closed)
     })]
     for (const pipe of pipes) pipe.end()
-    const unloading = Promise.all(unloaders)
+    const unloading = Promise.allSettled(unloaders)
     unloading.then(clear, clear)
     const result = await Promise.race([timeout, unloading])
     this.closed = true


### PR DESCRIPTION
`Promise.all` will reject as soon as one of the Promises in the array rejects.
`Promise.allSettled` will never reject - it will resolve once all Promises in the array have either rejected or resolved.







