### PR TITLE
electron: remove global shortcut for refresh: cmd+r

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -205,6 +205,7 @@ class Menu {
         label: 'Reload',
         accelerator: 'CmdOrCtrl+R',
         click (_, win) {
+          if (!win) return
           const view = win.getBrowserViews()[0]
           const { webContents } = view || win
           refresh(webContents, app.state)
@@ -257,19 +258,12 @@ class Menu {
 
   devtoolsReloaderListen (wc) {
     if (this.devtoolsReloaderActive) return
-
     this.devtoolsReloaderActive = true
-    const listener = () => { refresh(wc, this.app.state) }
-    // ignore electron docs about register: it DOES NOT accept an array of accelerators, just the one string
-    electron.globalShortcut.register('CommandOrControl+R', listener)
-    electron.globalShortcut.register('F5', listener)
   }
 
   devtoolsReloaderUnlisten () {
     if (this.devtoolsReloaderActive === false) return
     this.devtoolsReloaderActive = false
-    electron.globalShortcut.unregister('CommandOrControl+R')
-    electron.globalShortcut.unregister('F5')
   }
 
   destroy () {


### PR DESCRIPTION
* Hotkeys are no longer global / system-wide
* Hotkeys still work when focused on Pear window or Developer Tools
* Bonus: fixed a missing check for `undefined` that sometimes crashed when using the menu bar

(Manually tested on macOS and Linux)