### PR TITLE
fixed file-sharing for electron > 31

### DIFF
--- a/gui/preload.js
+++ b/gui/preload.js
@@ -49,6 +49,11 @@ module.exports = class PearGUI extends ReadyResource {
           return ipc.badge(count)
         }
 
+        this.electron = {}
+        this.electron.getPathForFile = (file) => {
+          return electron.webUtils.getPathForFile(file)
+        }
+
         const kGuiCtrl = Symbol('gui:ctrl')
 
         class Parent extends EventEmitter {


### PR DESCRIPTION
The upcoming release of platform (1.9) includes the upgrade of the electron runtime to version 33. Since version 32, the file objects in the html `input` with type `file` does not include the path of the file. So the preload (which has access to the right context to read a file path) exposes the getPathForFile from the webUtils.

See: https://www.electronjs.org/blog/electron-32-0 and https://github.com/electron/electron/pull/42053/files