### PR TITLE
improve pear stage when module not found

### DIFF
--- a/subsystems/sidecar/ops/stage.js
+++ b/subsystems/sidecar/ops/stage.js
@@ -118,7 +118,7 @@ module.exports = class Stage extends Opstream {
     if (dryRun) {
       this.push({ tag: 'skipping', data: { reason: 'dry-run', success: true } })
     } else if (mirror.count.add || mirror.count.remove || mirror.count.change) {
-      const analyzer = new DriveAnalyzer(bundle.drive)
+      const analyzer = new DriveAnalyzer(bundle.drive, { ignoreModuleNotFound: true })
       await analyzer.ready()
       const prefetch = state.manifest.pear?.stage?.prefetch || []
       const warmup = await analyzer.analyze(entrypoints, prefetch)


### PR DESCRIPTION
Issue: stage failed if some module is not found, e.g. this happens when someone wants to stage `_template` for pear init

e.g. add `<script type='module' src='build/bundle.js'></script>` to examples/desktop
```
<!DOCTYPE html>
<html>
  ...
  <script src="./app.js" type="module"></script>
  <script type='module' src='build/bundle.js'></script>
</body>
</html>
```

error from staging
![image](https://github.com/user-attachments/assets/9bb9db84-71c3-4c93-8f5f-b47815a852a6)
