### PR TITLE
improve workerRun

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1550,10 +1550,7 @@ class PearGUI extends ReadyResource {
       pipe.on('data', (data) => { evt.reply('workerPipeData', data) })
       pipe.on('end', () => { evt.reply('workerPipeEnd') })
       pipe.on('error', (err) => { evt.reply('workerPipeError', err.stack) })
-    })
-
-    electron.ipcMain.on('workerPipeId', (evt) => {
-      evt.returnValue = this.pipes.nextId()
+      evt.returnValue = id
       return evt.returnValue
     })
 

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -348,8 +348,7 @@ class IPC {
   }
 
   workerRun (link, args) {
-    const id = electron.ipcRenderer.sendSync('workerPipeId')
-    electron.ipcRenderer.send('workerRun', link, args)
+    const id = electron.ipcRenderer.sendSync('workerRun', link, args)
     const stream = new streamx.Duplex({
       write (data, cb) {
         electron.ipcRenderer.send('workerPipeWrite', id, data)


### PR DESCRIPTION
get id directly in one call instead of making 2 calls