### PR TITLE
improve tray darkMode ipc

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1591,8 +1591,10 @@ class PearGUI extends ReadyResource {
       pipe.write(data)
     })
 
-    electron.nativeTheme.on('updated', () => {
-      this.message({ type: 'pear/gui/tray/darkMode', darkMode: getDarkMode() })
+    electron.ipcMain.on('tray/darkMode', (evt) => {
+      electron.nativeTheme.on('updated', () => {
+        evt.reply('tray/darkMode', getDarkMode())
+      })
     })
   }
 

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -55,9 +55,10 @@ module.exports = class PearGUI extends ReadyResource {
         this.tray.scaleFactor = state.tray?.scaleFactor
         this.tray.darkMode = state.tray?.darkMode
 
-        ipc.messages({ type: 'pear/gui/tray/darkMode' }).on('data', (msg) => {
-          this.tray.darkMode = msg.darkMode
+        electron.ipcRenderer.on('tray/darkMode', (e, data) => {
+          this.tray.darkMode = data
         })
+        electron.ipcRenderer.send('tray/darkMode')
 
         const kGuiCtrl = Symbol('gui:ctrl')
 


### PR DESCRIPTION
- ipc only between gui and preload
- remove redundant ipc to sidecar