### PR TITLE
Add Pear.Window.self.quit()

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1303,6 +1303,11 @@ class Window extends GuiCtrl {
     this.closing = false
     return closed
   }
+
+  async quit () {
+    this.quitting = true
+    return this.close()
+  }
 }
 
 class View extends GuiCtrl {
@@ -1504,6 +1509,7 @@ class PearGUI extends ReadyResource {
     electron.ipcMain.handle('parent', (evt, ...args) => this.parent(...args))
     electron.ipcMain.handle('open', (evt, ...args) => this.open(...args))
     electron.ipcMain.handle('close', (evt, ...args) => this.guiClose(...args))
+    electron.ipcMain.handle('quit', (evt, ...args) => this.quit(...args))
     electron.ipcMain.handle('show', (evt, ...args) => this.show(...args))
     electron.ipcMain.handle('hide', (evt, ...args) => this.hide(...args))
     electron.ipcMain.handle('minimize', (evt, ...args) => this.minimize(...args))
@@ -1724,6 +1730,8 @@ class PearGUI extends ReadyResource {
 
   // guiClose because ReadyResource needs close (affects internal naming only)
   guiClose ({ id }) { return this.get(id).close() }
+  
+  quit ({ id }) { return this.get(id).quit() }
 
   show ({ id }) { return this.get(id).show() }
 

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1730,7 +1730,7 @@ class PearGUI extends ReadyResource {
 
   // guiClose because ReadyResource needs close (affects internal naming only)
   guiClose ({ id }) { return this.get(id).close() }
-  
+
   quit ({ id }) { return this.get(id).quit() }
 
   show ({ id }) { return this.get(id).show() }

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -99,6 +99,7 @@ module.exports = class PearGUI extends ReadyResource {
           fullscreen () { return ipc.fullscreen({ id: this.id }) }
           restore () { return ipc.restore({ id: this.id }) }
           close () { return ipc.close({ id: this.id }) }
+          quit () { return ipc.quit({ id: this.id }) }
           dimensions (options = null) { return ipc.dimensions({ id: this.id, options }) }
           isVisible () { return ipc.isVisible({ id: this.id }) }
           isMinimized () { return ipc.isMinimized({ id: this.id }) }
@@ -240,7 +241,7 @@ module.exports = class PearGUI extends ReadyResource {
             return
           }
           if (key === 'quit') {
-            this.exit(0)
+            this.Window.self.quit()
           }
         })
 
@@ -274,6 +275,7 @@ class IPC {
   parent (...args) { return electron.ipcRenderer.invoke('parent', ...args) }
   open (...args) { return electron.ipcRenderer.invoke('open', ...args) }
   close (...args) { return electron.ipcRenderer.invoke('close', ...args) }
+  quit (...args) { return electron.ipcRenderer.invoke('quit', ...args) }
   show (...args) { return electron.ipcRenderer.invoke('show', ...args) }
   hide (...args) { return electron.ipcRenderer.invoke('hide', ...args) }
   minimize (...args) { return electron.ipcRenderer.invoke('minimize', ...args) }


### PR DESCRIPTION
- When app is hideable, Pear.Window.self.close() does not quit the app anymore
- We should not call Pear.exit() because teardown will not run
=> hence, we need ipc.quit