### PR TITLE
fixed subcommands help

### DIFF
--- a/cmd/index.js
+++ b/cmd/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const { header, footer, command, flag, arg, summary, description, bail, sloppy } = require('paparam')
+const { header, footer, command, flag, arg, summary, description, bail, sloppy, rest } = require('paparam')
 const { usage, print } = require('./iface')
 const { CHECKOUT } = require('../constants')
 const errors = require('../errors')
@@ -199,8 +199,8 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     () => { console.log(data.help()) }
   )
 
-  const help = command('help', arg('[command]'), summary('View help for command'), (h) => {
-    if (h.args.command) console.log(cmd.help(h.args.command))
+  const help = command('help', rest('[command]'), summary('View help for command'), (h) => {
+    if (h.rest) console.log(cmd.help(...h.rest))
     else console.log(cmd.overview({ full: true }))
   })
 


### PR DESCRIPTION
This PR fixes `pear help command subcommand`

```
~/hyper/pear$ peardev help data apps
  Pear ~ Welcome to the Internet of Peers
  🍐 v0.dev./home/rafapaezbas/hyper/pear

pear data apps [flags] [link]

Installed apps

Arguments:
  [link]      Optional. Filter by Pear link

Flags:
  --help|-h   Show help

🍐 0.dev./home/rafapaezbas/hyper/pear
pears.com | holepunch.to | keet.io
Pear ~ Welcome to the IoP
```
