### PR TITLE
restore devtools global shortcut

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -279,11 +279,19 @@ class Menu {
   devtoolsReloaderListen (wc) {
     if (this.devtoolsReloaderActive) return
     this.devtoolsReloaderActive = true
+
+    const listener = () => { refresh(wc, this.app.state) }
+    // ignore electron docs about register: it DOES NOT accept an array of accelerators, just the one string
+    electron.globalShortcut.register('CommandOrControl+R', listener)
+    electron.globalShortcut.register('F5', listener)
   }
 
   devtoolsReloaderUnlisten () {
     if (this.devtoolsReloaderActive === false) return
     this.devtoolsReloaderActive = false
+
+    electron.globalShortcut.unregister('CommandOrControl+R')
+    electron.globalShortcut.unregister('F5')
   }
 
   destroy () {
@@ -417,7 +425,6 @@ class App {
       let devtoolsBlurPolling = null
       wc.on('devtools-opened', () => {
         devtoolsBlurPolling = setInterval(() => {
-          if (this.menu.globalReloaderActive === false) return
           if (wc.isDevToolsFocused() === false) this.menu.devtoolsReloaderUnlisten()
         }, 150)
       })


### PR DESCRIPTION
- call the `refresh` function when cmd+r
- remove dead code `globalReloaderActive`
- note that there is a polling logic to check if devtools is unfocused, then unregister global shorcut (we need to unregister global shorcut so that it will not reload all running apps, should reload active app only)
https://github.com/holepunchto/pear/blob/c666cb54e72153e8279e113700e9756dd6838dac/gui/gui.js#L423-L430
