### PR TITLE
[pear-next] fix `this.dhtBootstrap` as array

### DIFF
--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -28,7 +28,8 @@ const {
   WAKEUP, SALT, KNOWN_NODES_LIMIT
 } = require('pear-api/constants')
 const { ERR_INTERNAL_ERROR, ERR_PERMISSION_REQUIRED } = require('pear-api/errors')
-const DHT_BOOTSTRAP = require('pear-api/cmd')(Bare.argv.slice(1)).flags.dhtBootstrap?.split(',')
+const DHT_BOOTSTRAP = require('pear-api/cmd')(Bare.argv.slice(1))
+  .flags.dhtBootstrap?.split(',')
   .map((hostPort) => {
     const [host, portStr] = hostPort.split(':')
     const port = Number(portStr)

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -28,12 +28,13 @@ const {
   WAKEUP, SALT, KNOWN_NODES_LIMIT
 } = require('pear-api/constants')
 const { ERR_INTERNAL_ERROR, ERR_PERMISSION_REQUIRED } = require('pear-api/errors')
-const DHT_BOOTSTRAP = require('pear-api/cmd')(Bare.argv.slice(1)).flags.dhtBootstrap
-  .split(',')
-  .map(e => ({
-    host: e.split(':')[0],
-    port: Number(e.split(':')[1])
-  }))
+const DHT_BOOTSTRAP = require('pear-api/cmd')(Bare.argv.slice(1)).flags.dhtBootstrap?.split(',')
+  .map((hostPort) => {
+    const [host, portStr] = hostPort.split(':')
+    const port = Number(portStr)
+    if (Number.isNaN(port)) throw new Error(`Invalid port: ${portStr}`)
+    return { host, port }
+  })
 const reports = require('./lib/reports')
 const Applings = require('./lib/applings')
 const Bundle = require('./lib/bundle')


### PR DESCRIPTION
* Resolved `TypeError: (opts.bootstrap || []).map is not a function`

```bash
    at new DHT (file:///Users/user/holepunch/pear-next/node_modules/dht-rpc/index.js:29:82)
    at new HyperDHT (file:///Users/user/holepunch/pear-next/node_modules/hyperdht/index.js:25:5)
    at new Hyperswarm (file:///Users/user/holepunch/pear-next/node_modules/hyperswarm/index.js:36:28)
    at #ensureSwarm (file:///Users/user/holepunch/pear-next/subsystems/sidecar/index.js:873:18)
    at async Sidecar._open (file:///Users/user/holepunch/pear-next/subsystems/sidecar/index.js:273:5)
    at async open (file:///Users/user/holepunch/pear-next/node_modules/ready-resource/index.js:40:5)
    at async #start (file:///Users/user/holepunch/pear-next/subsystems/sidecar/index.js:659:5)
    at async Sidecar.start (file:///Users/user/holepunch/pear-next/subsystems/sidecar/index.js:639:20)
    at async Method._callOnRequest (file:///Users/user/holepunch/pear-next/node_modules/tiny-buffer-rpc/index.js:217:20)
```