### PR TITLE
Add a space & quotes to clearly note what "value" was unrecognized

### DIFF
--- a/cmd/index.js
+++ b/cmd/index.js
@@ -276,7 +276,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     }
     const reason = bail.reason === 'UNKNOWN_FLAG'
       ? 'Unrecognized Flag: --' + bail.flag.name
-      : (bail.reason === 'UNKNOWN_ARG' ? 'Unrecognized Argument at index ' + bail.arg.index + ' with value' + bail.arg.value : bail.reason)
+      : (bail.reason === 'UNKNOWN_ARG' ? 'Unrecognized Argument at index ' + bail.arg.index + ' with value "' + bail.arg.value + '"' : bail.reason)
 
     print(reason, false)
     print('\n' + bail.command.usage())


### PR DESCRIPTION
Previously the error from `pear something` would result in the error message reading:

```
Unrecognized Argument at index 0 with valuesomething
```

With the formatting changes it now returns:

```
Unrecognized Argument at index 0 with value "something"
```