### PR TITLE
[pear-next] CLI command: pear data reset

### DIFF
--- a/cmd/data.js
+++ b/cmd/data.js
@@ -1,11 +1,14 @@
 'use strict'
 const parseLink = require('pear-api/parse-link')
-const { outputter, ansi } = require('pear-api/terminal')
+const { outputter, ansi, confirm } = require('pear-api/terminal')
 const { ERR_INVALID_INPUT } = require('pear-api/errors')
+const { PLATFORM_HYPERDB } = require('pear-api/constants')
 
 const padding = '    '
+const placeholder = '[ No results ]\n'
 
 const appsOutput = (bundles) => {
+  if (!bundles.length) return placeholder
   let out = ''
   for (const bundle of bundles) {
     out += `- ${ansi.bold(bundle.link)}\n`
@@ -20,6 +23,7 @@ const appsOutput = (bundles) => {
 }
 
 const dhtOutput = (nodes) => {
+  if (!nodes.length) return placeholder
   let out = ''
   for (const node of nodes) {
     out += `${node.host}${ansi.dim(`:${node.port}`)}\n`
@@ -28,6 +32,7 @@ const dhtOutput = (nodes) => {
 }
 
 const gcOutput = (records) => {
+  if (!records.length) return placeholder
   let out = ''
   for (const gc of records) {
     out += `- ${ansi.bold(gc.path)}\n`
@@ -39,7 +44,8 @@ const output = outputter('data', {
   apps: (result) => appsOutput(result),
   link: (result) => appsOutput([result]),
   dht: (result) => dhtOutput(result),
-  gc: (result) => gcOutput(result)
+  gc: (result) => gcOutput(result),
+  dataReset: () => 'Database cleared'
 })
 
 module.exports = (ipc) => new Data(ipc)
@@ -56,25 +62,36 @@ class Data {
     if (link) {
       const parsed = parseLink(link)
       if (!parsed) throw ERR_INVALID_INPUT(`Link "${link}" is not a valid key`)
-      const result = await this.ipc.data({ resource: 'link', secrets, link })
-      await output(json, result, { tag: 'link' }, this.ipc)
+      await output(json, this.ipc.data({ resource: 'link', secrets, link }), { tag: 'link' }, this.ipc)
     } else {
-      const result = await this.ipc.data({ resource: 'apps', secrets })
-      await output(json, result, { tag: 'apps' }, this.ipc)
+      await output(json, this.ipc.data({ resource: 'apps', secrets }), { tag: 'apps' }, this.ipc)
     }
   }
 
   async dht (cmd) {
     const { command } = cmd
     const { json } = command.parent.flags
-    const result = await this.ipc.data({ resource: 'dht' })
-    await output(json, result, { tag: 'dht' }, this.ipc)
+    await output(json, this.ipc.data({ resource: 'dht' }), { tag: 'dht' }, this.ipc)
   }
 
   async gc (cmd) {
     const { command } = cmd
     const { json } = command.parent.flags
-    const result = await this.ipc.data({ resource: 'gc' })
-    await output(json, result, { tag: 'gc' }, this.ipc)
+    await output(json, this.ipc.data({ resource: 'gc' }), { tag: 'gc' }, this.ipc)
+  }
+
+  async reset (cmd) {
+    const { command } = cmd
+    const { json } = command.parent.flags
+    const { yes } = command.flags
+    if (!yes) {
+      const dialog = `${ansi.warning} Clearing database ${ansi.bold(PLATFORM_HYPERDB)}\n\n`
+      const ask = 'Type DELETE to confirm'
+      const delim = '?'
+      const validation = (val) => val === 'DELETE'
+      const msg = '\n' + ansi.cross + ' uppercase DELETE to confirm\n'
+      await confirm(dialog, ask, delim, validation, msg)
+    }
+    await output(json, this.ipc.dataReset(), { tag: 'dataReset' }, this.ipc)
   }
 }

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -222,6 +222,9 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     command('apps', summary('Installed apps'), arg('[link]', 'Filter by link'), (cmd) => runners.data(ipc).apps(cmd)),
     command('dht', summary('DHT known-nodes cache'), (cmd) => runners.data(ipc).dht(cmd)),
     command('gc', summary('Garbage collection records'), (cmd) => runners.data(ipc).gc(cmd)),
+    command('reset', summary('Advanced. Clear local database'),
+      flag('--yes', 'Skip confirmation prompt'), (cmd) => runners.data(ipc).reset(cmd)
+    ),
     flag('--secrets', 'Show sensitive information, i.e. encryption-keys'),
     flag('--json', 'Newline delimited JSON output'),
     () => { console.log(data.help()) }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pear",
-  "version": "1.10.0-rc.0",
+  "version": "1.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pear",
-      "version": "1.10.0-rc.0",
+      "version": "1.11.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hyperswarm/seeders": "^1.1.6",
@@ -44,10 +44,10 @@
         "mirror-drive": "^1.4.0",
         "mutexify": "^1.4.0",
         "paparam": "^1.8.0",
-        "pear-api": "^1.6.4",
+        "pear-api": "^1.6.5",
         "pear-changelog": "^1.0.1",
         "pear-interface": "^1.0.0",
-        "pear-ipc": "^3.2.0",
+        "pear-ipc": "^3.3.0",
         "pear-link": "^2.1.1",
         "pear-updater": "^3.4.3",
         "pear-updater-bootstrap": "^1.2.0",
@@ -3874,9 +3874,10 @@
       }
     },
     "node_modules/pear-ipc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pear-ipc/-/pear-ipc-3.2.0.tgz",
-      "integrity": "sha512-ccuI0xYV7UA1TiBV5uhGCy06uS71uaVBTeLY+yF987DHEuc9ggLe9/AM9fuWRdWeI/NxjJQFQXedm+wEYUd7Zg==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pear-ipc/-/pear-ipc-3.3.0.tgz",
+      "integrity": "sha512-L2ZQ6r1UM+mVa0zxC/7B5B+K1bbvHms1makvS4gcNiwx9E1fXKWSVkvLZ0cfGf86+IH5YfzjJ63SbjTy77gABw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "bare-fs": "^4.0.1",
         "bare-os": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "pear-api": "^1.6.5",
     "pear-changelog": "^1.0.1",
     "pear-interface": "^1.0.0",
-    "pear-ipc": "^3.2.0",
+    "pear-ipc": "^3.3.0",
     "pear-link": "^2.1.1",
     "pear-updater": "^3.4.3",
     "pear-updater-bootstrap": "^1.2.0",

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -54,7 +54,8 @@ const ops = {
   Info: require('./ops/info'),
   Shift: require('./ops/shift'),
   Touch: require('./ops/touch'),
-  Data: require('./ops/data')
+  Data: require('./ops/data'),
+  DataReset: require('./ops/data/reset')
 }
 
 // ensure that we are registered as a link handler
@@ -350,6 +351,8 @@ class Sidecar extends ReadyResource {
   info (params, client) { return new ops.Info(params, client, this) }
 
   data (params, client) { return new ops.Data(params, client, this) }
+
+  dataReset (params, client) { return new ops.DataReset(params, client, this) }
 
   shift (params, client) { return new ops.Shift(params, client, this) }
 

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -1,4 +1,5 @@
 'use strict'
+const fs = require('bare-fs')
 const HyperDB = require('hyperdb')
 const DBLock = require('db-lock')
 const dbSpec = require('../../../spec/db')
@@ -6,6 +7,11 @@ const { PLATFORM_HYPERDB } = require('pear-api/constants')
 
 module.exports = class Model {
   constructor () {
+    this.init()
+  }
+
+  init () {
+    LOG.trace('db', `ROCKS ('${PLATFORM_HYPERDB}')`)
     this.db = HyperDB.rocks(PLATFORM_HYPERDB, dbSpec)
 
     this.lock = new DBLock({
@@ -145,6 +151,13 @@ module.exports = class Model {
   }
 
   async close () {
+    LOG.trace('db', 'CLOSE')
     await this.db.close()
+  }
+
+  async reset () {
+    await this.close()
+    await fs.promises.rm(PLATFORM_HYPERDB, { recursive: true, force: true })
+    this.init()
   }
 }

--- a/subsystems/sidecar/ops/data/index.js
+++ b/subsystems/sidecar/ops/data/index.js
@@ -1,6 +1,6 @@
 'use strict'
 const { pathToFileURL } = require('url-file-url')
-const Opstream = require('../lib/opstream')
+const Opstream = require('../../lib/opstream')
 
 module.exports = class Data extends Opstream {
   constructor (...args) {

--- a/subsystems/sidecar/ops/data/reset.js
+++ b/subsystems/sidecar/ops/data/reset.js
@@ -1,0 +1,13 @@
+'use strict'
+const Opstream = require('../../lib/opstream')
+
+module.exports = class DataReset extends Opstream {
+  constructor (...args) {
+    super((...args) => this.#op(...args), ...args)
+  }
+
+  async #op () {
+    await this.sidecar.model.reset()
+    this.push({ tag: 'dataReset' })
+  }
+}


### PR DESCRIPTION
IPC `dataReset` is already released `3.3.0` (https://github.com/holepunchto/pear-ipc/blob/main/methods.js#L45)

---

* removed `await` from `this.ipc.data` calls

* `rm` is now processed by the Sidecar process via a new IPC `dataReset`

* confirmation prompt uses local Pear `constants.PLATFORM_HYPERDB`

* Graceful model close & re-init

* `--yes` flag to skip prompt

* added `[ No results ]` as placeholder when length is zero

---

`pear data reset`

```
⚠️ Clearing database /Users/user/holepunch/pear/pear/db

Type DELETE to confirm? DELETE
Database cleared
✔ Success
```

---

`pear data reset --help`

```
pear data reset [flags]

Advanced. Clear local database

Flags:
  --yes       Skip confirmation prompt
  --help|-h   Show help
```

---

`--yes`

```
./pear.dev data reset --yes
✔ Success
```