### PR TITLE
[main] `pear data apps` fix duplicates

### DIFF
--- a/cmd/data.js
+++ b/cmd/data.js
@@ -4,14 +4,16 @@ const { outputter, ansi } = require('./iface')
 const { ERR_INVALID_INPUT } = require('../errors')
 
 const padding = '    '
+const placeholder = '[ No results ]\n'
 
 const appsOutput = (bundles) => {
+  if (!bundles.length || !bundles[0]) return placeholder
   let out = ''
   for (const bundle of bundles) {
     out += `- ${ansi.bold(bundle.link)}\n`
-    out += `${padding}appStorage: ${ansi.dim(bundle.appStorage)}\n`
+    out += `${padding}storage: ${ansi.dim(bundle.appStorage)}\n`
     if (bundle.encryptionKey) {
-      out += `${padding}encryptionKey: ${ansi.dim(bundle.encryptionKey.toString('hex'))}\n`
+      out += `${padding}encryption: ${ansi.dim(bundle.encryptionKey.toString('hex'))}\n`
     }
     if (bundle.tags) out += `${padding}tags: ${ansi.dim(bundle.tags)}\n`
     out += '\n'
@@ -20,6 +22,7 @@ const appsOutput = (bundles) => {
 }
 
 const dhtOutput = (nodes) => {
+  if (!nodes.length) return placeholder
   let out = ''
   for (const node of nodes) {
     out += `${node.host}${ansi.dim(`:${node.port}`)}\n`
@@ -28,6 +31,7 @@ const dhtOutput = (nodes) => {
 }
 
 const gcOutput = (records) => {
+  if (!records.length) return placeholder
   let out = ''
   for (const gc of records) {
     out += `- ${ansi.bold(gc.path)}\n`

--- a/cmd/data.js
+++ b/cmd/data.js
@@ -13,7 +13,7 @@ const appsOutput = (bundles) => {
     out += `- ${ansi.bold(bundle.link)}\n`
     out += `${padding}storage: ${ansi.dim(bundle.appStorage)}\n`
     if (bundle.encryptionKey) {
-      out += `${padding}encryption: ${ansi.dim(bundle.encryptionKey.toString('hex'))}\n`
+      out += `${padding}encryptionKey: ${ansi.dim(bundle.encryptionKey.toString('hex'))}\n`
     }
     if (bundle.tags) out += `${padding}tags: ${ansi.dim(bundle.tags)}\n`
     out += '\n'

--- a/package-lock.json
+++ b/package-lock.json
@@ -4126,7 +4126,7 @@
     },
     "node_modules/pear-link": {
       "version": "2.1.2",
-      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#1f709e1eaa8afd58dd2056e1af508e3ad61de10c",
+      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#791e7ab53a7cd86424ee08a66f4628ec770452f0",
       "license": "Apache-2.0",
       "dependencies": {
         "hypercore-id-encoding": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4126,7 +4126,7 @@
     },
     "node_modules/pear-link": {
       "version": "2.1.2",
-      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#642760a1828c3aa11c0f914c79c6345273dae24a",
+      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#f32ef92867191e95930ecc7782c55fdfa701d226",
       "license": "Apache-2.0",
       "dependencies": {
         "hypercore-id-encoding": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4126,7 +4126,7 @@
     },
     "node_modules/pear-link": {
       "version": "2.1.2",
-      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#2379d2b2e1ec8f6de21da9936ad74347b088ce4f",
+      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#80cc9b581cab0b8df1c40eecd5dd548da6b36b1c",
       "license": "Apache-2.0",
       "dependencies": {
         "hypercore-id-encoding": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4126,7 +4126,7 @@
     },
     "node_modules/pear-link": {
       "version": "2.1.2",
-      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#791e7ab53a7cd86424ee08a66f4628ec770452f0",
+      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#2379d2b2e1ec8f6de21da9936ad74347b088ce4f",
       "license": "Apache-2.0",
       "dependencies": {
         "hypercore-id-encoding": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4126,7 +4126,7 @@
     },
     "node_modules/pear-link": {
       "version": "2.1.2",
-      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#80cc9b581cab0b8df1c40eecd5dd548da6b36b1c",
+      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#642760a1828c3aa11c0f914c79c6345273dae24a",
       "license": "Apache-2.0",
       "dependencies": {
         "hypercore-id-encoding": "^1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "pear-changelog": "^1.0.1",
         "pear-interface": "^1.0.0",
         "pear-ipc": "^5.0.1",
-        "pear-link": "^2.1.1",
+        "pear-link": "github:AndreiRegiani/pear-link#root-function",
         "pear-updater": "^3.4.3",
         "pear-updater-bootstrap": "^2.0.0",
         "protomux": "^3.6.0",
@@ -4126,11 +4126,11 @@
     },
     "node_modules/pear-link": {
       "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/pear-link/-/pear-link-2.1.2.tgz",
-      "integrity": "sha512-W9U2JYBAvgSo1oHnQaZwA7fXvurrlIiYw0/7oPHJjSnKYE15misl3PCtfrw16pPeDRwrFcqADAYfXGUaiWrTBg==",
+      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#1f709e1eaa8afd58dd2056e1af508e3ad61de10c",
       "license": "Apache-2.0",
       "dependencies": {
         "hypercore-id-encoding": "^1.2.0",
+        "url-file-url": "^1.0.5",
         "which-runtime": "^1.2.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "pear-changelog": "^1.0.1",
         "pear-interface": "^1.0.0",
         "pear-ipc": "^5.0.1",
-        "pear-link": "github:AndreiRegiani/pear-link#root-function",
+        "pear-link": "^2.2.1",
         "pear-updater": "^3.4.3",
         "pear-updater-bootstrap": "^2.0.0",
         "protomux": "^3.6.0",
@@ -4125,9 +4125,9 @@
       }
     },
     "node_modules/pear-link": {
-      "version": "2.1.2",
-      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#f32ef92867191e95930ecc7782c55fdfa701d226",
-      "license": "Apache-2.0",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/pear-link/-/pear-link-2.2.1.tgz",
+      "integrity": "sha512-ZpI/uzJl02t3ZCOGZ9U7WeOGC/HZeMJW2o1Qsq27hwWykKAXH0AIVqJm0xFcO5Oxxdeno3rFShGymKGk1bF0aA==",
       "dependencies": {
         "hypercore-id-encoding": "^1.2.0",
         "url-file-url": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "pear-changelog": "^1.0.1",
     "pear-interface": "^1.0.0",
     "pear-ipc": "^5.0.1",
-    "pear-link": "^2.1.1",
+    "pear-link": "github:AndreiRegiani/pear-link#root-function",
     "pear-updater": "^3.4.3",
     "pear-updater-bootstrap": "^2.0.0",
     "protomux": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "pear-changelog": "^1.0.1",
     "pear-interface": "^1.0.0",
     "pear-ipc": "^5.0.1",
-    "pear-link": "github:AndreiRegiani/pear-link#root-function",
+    "pear-link": "^2.2.1",
     "pear-updater": "^3.4.3",
     "pear-updater-bootstrap": "^2.0.0",
     "protomux": "^3.6.0",

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -683,7 +683,7 @@ class Sidecar extends ReadyResource {
       }
     }
 
-    link = pearLink.normalize(link.startsWith('pear://') ? link : pathToFileURL(link).href)
+    link = pearLink.normalize(link.startsWith('pear://') ? `pear://${hypercoreid.encode(key)}` : pathToFileURL(link).href)
     const persistedBundle = await this.model.getBundle(link) || await this.model.addBundle(link, State.storageFromLink(parsedLink))
     const encryptionKey = persistedBundle.encryptionKey
     const appStorage = persistedBundle.appStorage

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -3,6 +3,7 @@ const HyperDB = require('hyperdb')
 const DBLock = require('db-lock')
 const pearLink = require('pear-link')
 const dbSpec = require('../../../spec/db')
+const { ALIASES } = require('../../../constants')
 
 module.exports = class Model {
   constructor (corestore) {
@@ -20,9 +21,9 @@ module.exports = class Model {
   }
 
   async getBundle (link) {
-    link = pearLink.origin(link)
-    LOG.trace('db', `GET ('@pear/bundle', ${JSON.stringify({ link })})`)
-    const bundle = await this.db.get('@pear/bundle', { link })
+    const { origin } = pearLink(ALIASES)(link)
+    LOG.trace('db', `GET ('@pear/bundle', ${JSON.stringify({ link: origin })})`)
+    const bundle = await this.db.get('@pear/bundle', { link: origin })
     return bundle
   }
 
@@ -32,10 +33,10 @@ module.exports = class Model {
   }
 
   async addBundle (link, appStorage) {
-    link = pearLink.origin(link)
+    const { origin } = pearLink(ALIASES)(link)
     const tx = await this.lock.enter()
-    LOG.trace('db', `INSERT ('@pear/bundle', ${JSON.stringify({ link, appStorage })})`)
-    await tx.insert('@pear/bundle', { link, appStorage })
+    LOG.trace('db', `INSERT ('@pear/bundle', ${JSON.stringify({ link: origin, appStorage })})`)
+    await tx.insert('@pear/bundle', { link: origin, appStorage })
     await this.lock.exit()
     return { link, appStorage }
   }

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -1,6 +1,7 @@
 'use strict'
 const HyperDB = require('hyperdb')
 const DBLock = require('db-lock')
+const pearLink = require('pear-link')
 const dbSpec = require('../../../spec/db')
 
 module.exports = class Model {
@@ -19,6 +20,7 @@ module.exports = class Model {
   }
 
   async getBundle (link) {
+    link = pearLink.origin(link)
     LOG.trace('db', `GET ('@pear/bundle', ${JSON.stringify({ link })})`)
     const bundle = await this.db.get('@pear/bundle', { link })
     return bundle
@@ -30,6 +32,7 @@ module.exports = class Model {
   }
 
   async addBundle (link, appStorage) {
+    link = pearLink.origin(link)
     const tx = await this.lock.enter()
     LOG.trace('db', `INSERT ('@pear/bundle', ${JSON.stringify({ link, appStorage })})`)
     await tx.insert('@pear/bundle', { link, appStorage })

--- a/subsystems/sidecar/ops/data.js
+++ b/subsystems/sidecar/ops/data.js
@@ -1,5 +1,4 @@
 'use strict'
-const { pathToFileURL } = require('url-file-url')
 const Opstream = require('../lib/opstream')
 
 module.exports = class Data extends Opstream {
@@ -15,8 +14,7 @@ module.exports = class Data extends Opstream {
     }
 
     if (resource === 'link') {
-      const isPearLink = link.startsWith('pear://')
-      const bundle = await this.sidecar.model.getBundle(isPearLink ? link : pathToFileURL(link).href)
+      const bundle = await this.sidecar.model.getBundle(link)
       if (bundle && !secrets) bundle.encryptionKey = undefined
       this.push({ tag: 'link', data: bundle })
     }

--- a/test/10-data.test.js
+++ b/test/10-data.test.js
@@ -125,7 +125,8 @@ test('no duplicated bundle local app', async function ({ is, comment, teardown }
   const result = await Helper.pick(data, [{ tag: 'apps' }])
   const bundles = await result.apps
 
-  const persistedBundles = bundles.filter(e => e.link.startsWith(`file://${versionsDir}`))
+  const key = isWindows ? `file:///${versionsDir.replaceAll('\\', '/')}` : `file://${versionsDir}`
+  const persistedBundles = bundles.filter(e => e.link.startsWith(key))
   is(persistedBundles.length, 1, 'single bundle persisted')
-  is(persistedBundles[0].link, isWindows ? 'file:///{versionsDir}' : `file://${versionsDir}`, 'bundle key is origin key')
+  is(persistedBundles[0].link, key, 'bundle key is origin key')
 })


### PR DESCRIPTION
* Bug fix: normalize bundle links to avoid duplicates (trim #segments and paths, keep origin) 

Dependency: https://github.com/holepunchto/pear-link/pull/7

```bash
pear run pear://keet/foo#bar
# inserts to db `pear://keet`
```

---

Sub-tasks:

* Bug fix: handle null error on `pear data apps {link not found}`
* Cosmetic: renamed stdout labels: `appStorage` -> `storage` & `encryptionKey` -> `encryption`

---

* Bug fix: `pear data apps {link}` now supports different lookups:

```bash
# inputs

/Users/user/holepunch/pear-desktop
/Users/user/holepunch/pear-desktop/
file:///Users/user/holepunch/pear-desktop
file:///Users/user/holepunch/pear-desktop/

# same output

file:///Users/user/holepunch/pear-desktop
```
