### PR TITLE
run worker from desktop bundle

### DIFF
--- a/def/run.js
+++ b/def/run.js
@@ -24,5 +24,6 @@ module.exports = [
   flag('--swap <path>').hide(),
   flag('--start-id <id>').hide(),
   flag('--sandbox').hide(), // electron passthrough
-  flag('--app-name <name>').hide()
+  flag('--app-name <name>').hide(),
+  flag('--module <folder>').hide()
 ]

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1560,8 +1560,8 @@ class PearGUI extends ReadyResource {
       }
     })
 
-    electron.ipcMain.on('workerRun', (evt, link, args) => {
-      const pipe = this.worker.run(link, args)
+    electron.ipcMain.on('workerRun', (evt, link, args, runArgs) => {
+      const pipe = this.worker.run(link, args, runArgs)
       const id = this.pipes.alloc(pipe)
       pipe.on('close', () => {
         this.pipes.free(id)

--- a/gui/preload.js
+++ b/gui/preload.js
@@ -348,9 +348,9 @@ class IPC {
     return stream
   }
 
-  workerRun (link, args) {
+  workerRun (link, args, runArgs) {
     const id = electron.ipcRenderer.sendSync('workerPipeId')
-    electron.ipcRenderer.send('workerRun', link, args)
+    electron.ipcRenderer.send('workerRun', link, args, runArgs)
     const stream = new streamx.Duplex({
       write (data, cb) {
         electron.ipcRenderer.send('workerPipeWrite', id, data)

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -25,7 +25,7 @@ class Worker {
     this.#ipc = ipc
   }
 
-  #args (link) {
+  #args (link, runArgs) {
     const parser = command('pear', command('run', ...rundef))
     const sliced = program.argv.slice(1)
     const cmdIdx = shell(sliced).indices.args.cmd
@@ -41,12 +41,13 @@ class Worker {
     }
     if (linksIndex > 0) args.splice(linksIndex, linksElements)
     if (!cmd.flags.trusted) args.splice(1, 0, '--trusted')
+    args.splice(args.length - 1, 0, ...runArgs)
     return args
   }
 
-  run (link, args = []) {
-    if (isElectronRenderer) return this.#ipc.workerRun(link, args)
-    args = [...this.#args(link), ...args]
+  run (link, args = [], runArgs = []) {
+    if (isElectronRenderer) return this.#ipc.workerRun(link, args, runArgs)
+    args = [...this.#args(link, runArgs), ...args]
     const sp = spawn(this.constructor.RUNTIME, args, {
       stdio: ['inherit', 'inherit', 'inherit', 'overlapped'],
       windowsHide: true

--- a/state.js
+++ b/state.js
@@ -123,7 +123,7 @@ module.exports = class State {
     const segment = pathname?.startsWith('/') ? pathname.slice(1) : pathname
     const fragment = hash ? hash.slice(1) : (this.constructor.isKeetInvite(segment) ? segment : null)
     const entrypoint = this.constructor.isEntrypoint(pathname) ? pathname : null
-    const pkgPath = path.join(dir, 'package.json')
+    const pkgPath = path.join(dir, flags.module || '', 'package.json')
     const pkg = key === null ? readPkg(pkgPath) : null
     const store = flags.tmpStore ? path.join(os.tmpdir(), crypto.randomBytes(16).toString('hex')) : flags.store
     this.#onupdate = onupdate

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -741,6 +741,9 @@ class Sidecar extends ReadyResource {
       LOG.info(LOG_RUN_LINK, id, type, 'app')
       const isTerminalApp = type === 'terminal'
       if (isTerminalApp) LOG.info(LOG_RUN_LINK, id, 'making Bare bundle')
+      if (flags.module && !state.entrypoint) {
+        state.entrypoint = path.join('/', flags.module, state.manifest.main || '.')
+      }
       const bundle = isTerminalApp ? await app.bundle.bundle(state.entrypoint) : null
       LOG.info(LOG_RUN_LINK, id, 'run initialization complete')
       return { port: this.port, id, startId, host: `http://127.0.0.1:${this.port}`, bail: updating, type, bundle, app: { name: state.appName } }
@@ -842,6 +845,9 @@ class Sidecar extends ReadyResource {
     const type = state.type
     const isTerminalApp = type === 'terminal'
     if (isTerminalApp) LOG.info(LOG_RUN_LINK, id, 'making Bare bundle')
+    if (flags.manifest && !state.entrypoint) {
+      state.entrypoint = path.join('/', flags.module, state.manifest.main || '.')
+    }
     const bundle = isTerminalApp ? await app.bundle.bundle(state.entrypoint) : null
     LOG.info(LOG_RUN_LINK, id, 'run initialization complete')
     return { port: this.port, id, startId, host: `http://127.0.0.1:${this.port}`, bail: updating, type, bundle, app: { name: state.appName } }

--- a/subsystems/sidecar/state.js
+++ b/subsystems/sidecar/state.js
@@ -36,18 +36,19 @@ module.exports = class State extends SharedState {
       if (bundle.drive.core.length === 0) {
         await bundle.drive.core.update()
       }
-      const result = await bundle.db.get('manifest')
+      const manifestPath = this.flags.module ? path.join(this.flags.module, 'package.json') : null
+      const result = !manifestPath ? (await bundle.db.get('manifest'))?.value : JSON.parse((await bundle.drive.get(manifestPath))?.toString())
       if (app?.reported) return
       if (result === null) {
         throw ERR_INVALID_MANIFEST(`unable to fetch manifest from app pear://${hypercoreid.encode(this.key)}`)
       }
-      if (result.value === null) {
+      if (result === null) {
         throw ERR_INVALID_MANIFEST(`empty manifest found from app pear://${hypercoreid.encode(this.key)}`)
       }
-      this.constructor.injestPackage(this, result.value)
+      this.constructor.injestPackage(this, result)
     } else if (this.stage) {
       const result = await bundle.db.get('manifest')
-      if (!result || !sameData(result.value, this.manifest)) {
+      if (!result || !sameData(result, this.manifest)) {
         if (dryRun === false && this.manifest) {
           await bundle.db.put('manifest', this.manifest)
         }


### PR DESCRIPTION
Adds support for running a Pear app with an alternative manifest, enabling a worker to run from the same bundle as the desktop application:
 
`Pear.worker.run(Pear.key ? Pear.config.link : Pear.config.dir, [], ['--module', 'worker-folder'])`