### PR TITLE
`file://` links fix

### DIFF
--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -720,7 +720,13 @@ class Sidecar extends ReadyResource {
       }
     }
 
-    link = pearLink.normalize(link.startsWith('pear://') ? `pear://${hypercoreid.encode(key)}${parsedLink.pathname}${parsedLink.hash}` : pathToFileURL(link).href)
+    if (link.startsWith('pear://')) {
+      link = `pear://${hypercoreid.encode(key)}${parsedLink.pathname}${parsedLink.hash}`
+    } else if (!link.startsWith('file://')) {
+      link = pathToFileURL(link).href
+    }
+    link = pearLink.normalize(link)
+
     const { encryptionKey, appStorage } = await this.model.getBundle(link) || await this.model.addBundle(link, State.storageFromLink(parsedLink))
 
     await fs.promises.mkdir(appStorage, { recursive: true })

--- a/test/09-data.test.js
+++ b/test/09-data.test.js
@@ -147,6 +147,10 @@ test('no duplicated bundle local app', async function ({ is, comment, teardown }
   const runB = await Helper.run({ link: versionsDir + '#fragment' })
   await Helper.untilClose(runB.pipe)
 
+  comment(`running file://${versionsDir}`)
+  const runC = await Helper.run({ link: 'file://' + versionsDir })
+  await Helper.untilClose(runC.pipe)
+
   const data = await helper.data({ resource: 'apps' })
   const result = await Helper.pick(data, [{ tag: 'apps' }])
   const bundles = await result.apps


### PR DESCRIPTION
<img width="1145" alt="Screenshot 2025-04-10 at 17 15 24" src="https://github.com/user-attachments/assets/7bef6120-7c85-4a4d-b0e0-939c864fdbb5" />

---

BEFORE fix, the new unit fails as expected:

<img width="811" alt="Screenshot 2025-04-10 at 16 54 06" src="https://github.com/user-attachments/assets/c2bcf3bc-7d49-433d-8e05-c2a536d8ced9" />
