### PR TITLE
fix: set exit code to 1 during cmd bail on arbitrary error

### DIFF
--- a/cmd/index.js
+++ b/cmd/index.js
@@ -279,5 +279,6 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
 
     print(reason, false)
     print('\n' + bail.command.usage())
+    Bare.exit(1)
   }
 }

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -279,6 +279,6 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
 
     print(reason, false)
     print('\n' + bail.command.usage())
-    Bare.exit(1)
+    Bare.exitCode = 1
   }
 }


### PR DESCRIPTION
Pear process currently returns exit code 0 when detecting a known error. The intention behind this PR is to make the Pear process exit with code 1, regardless of whether the error is known or not.