### PR TITLE
[pear-next] examples/desktop: closeHides: false

### DIFF
--- a/examples/desktop/package.json
+++ b/examples/desktop/package.json
@@ -15,7 +15,8 @@
       "width": 900,
       "height": 500,
       "minWidth": 500,
-      "backgroundColor": "#1F2430"
+      "backgroundColor": "#1F2430",
+      "closeHides": false
     }
   },
   "devDependencies": {


### PR DESCRIPTION
```
"closeHides": false
```

(same effect as omitting, but serves as documentation for example app)