### PR TITLE
Default app name in init cmd suggestion removes whitespace & is lowercase

### DIFF
--- a/cmd/init.js
+++ b/cmd/init.js
@@ -31,7 +31,7 @@ module.exports = (ipc) => async function init (cmd) {
   const name = cfg?.name || pkg?.name || basename(dir)
   const link = wither(type, w) || cmd.args.link || 'desktop'
 
-  const defaults = { height, width, name }
+  const defaults = { height, width, name: name.toLowerCase() }
 
   const banner = `${ansi.bold(name)} ~ ${ansi.dim('Welcome to the Internet of Peers')}`
   let header = `\n${banner}${ansi.dim('›')}\n\n`

--- a/cmd/init.js
+++ b/cmd/init.js
@@ -31,7 +31,7 @@ module.exports = (ipc) => async function init (cmd) {
   const name = cfg?.name || pkg?.name || basename(dir)
   const link = wither(type, w) || cmd.args.link || 'desktop'
 
-  const defaults = { height, width, name: name.toLowerCase() }
+  const defaults = { height, width, name: name.replace(/\s/g, '-').toLowerCase() }
 
   const banner = `${ansi.bold(name)} ~ ${ansi.dim('Welcome to the Internet of Peers')}`
   let header = `\n${banner}${ansi.dim('›')}\n\n`


### PR DESCRIPTION
Suggesting a name with hyphens (-) instead of whitespaces and lowercase means less times when a developer hits the invalid name error message:
```
Bail: Error: The package.json name / pear.name field must be lowercase and one word, and may contain letters, numbers, hyphens (-), underscores (_), forward slashes (/) and asperands (@).
```