### PR TITLE
[pear-next] upgrade `pear-link` to fix `test('no duplicated bundle local app)`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "pear-changelog": "^1.0.1",
         "pear-interface": "^1.1.0",
         "pear-ipc": "^6.1.0",
+        "pear-link": "github:AndreiRegiani/pear-link#file-fragment-fix",
         "pear-updater": "^3.4.3",
         "pear-updater-bootstrap": "^2.0.0",
         "protomux": "^3.10.1",
@@ -614,16 +615,6 @@
         "bare-buffer": {
           "optional": true
         }
-      }
-    },
-    "node_modules/bare-debug-log": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/bare-debug-log/-/bare-debug-log-2.0.0.tgz",
-      "integrity": "sha512-Vi42PkMQsNV9PUpx2Gl1hikshx5O9FzMJ6o9Nnopseg7qLBBK7Nl31d0RHcfwLEAfmcPApytpc0ZFfq68u22FQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-daemon": {
@@ -2370,7 +2361,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.5.tgz",
       "integrity": "sha512-1zccWBMypln0jEE05LzZt+V/8y8AQsQQqxtklqaIyg5nu6OAYFhZxPXinJTSG+kU5qyNmeLgcn9AW7eHiCHVLA==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bare-events": "^2.5.4",
@@ -4082,8 +4072,8 @@
     },
     "node_modules/pear-link": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pear-link/-/pear-link-3.0.0.tgz",
-      "integrity": "sha512-BdVopCmehdeHsx/1z7X77Fw68RHJEgbQJb3Y8jfsSsqoIAHlgmtgeh1DoccQhGmmlCUyGR2QzSiLZ3ztzAzWLA==",
+      "resolved": "git+ssh://git@github.com/AndreiRegiani/pear-link.git#8f8a1d29a8f9d9e155d57ff37289ff18db4cc8e9",
+      "license": "Apache-2.0",
       "dependencies": {
         "hypercore-id-encoding": "^1.2.0",
         "url-file-url": "^1.0.5",
@@ -4652,18 +4642,6 @@
         "read-write-mutexify": "^2.0.0",
         "source-map-bare": "^1.0.0",
         "unix-path-resolve": "^1.0.2"
-      }
-    },
-    "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "pear-changelog": "^1.0.1",
     "pear-interface": "^1.1.0",
     "pear-ipc": "^6.1.0",
-    "pear-link": "github:AndreiRegiani/pear-link#file-fragment-fix",
+    "pear-link": "^3.0.1",
     "pear-updater": "^3.4.3",
     "pear-updater-bootstrap": "^2.0.0",
     "protomux": "^3.10.1",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "pear-changelog": "^1.0.1",
     "pear-interface": "^1.1.0",
     "pear-ipc": "^6.1.0",
+    "pear-link": "github:AndreiRegiani/pear-link#file-fragment-fix",
     "pear-updater": "^3.4.3",
     "pear-updater-bootstrap": "^2.0.0",
     "protomux": "^3.10.1",


### PR DESCRIPTION
https://github.com/holepunchto/pear-link/pull/9
