### PR TITLE
[pear-next] `npm run bootstrap` Force fetch win32-x64 on Windows ARM

### DIFF
--- a/scripts/bootstrap.js
+++ b/scripts/bootstrap.js
@@ -34,7 +34,8 @@ const RUNTIMES_DRIVE_KEY = cmd.rest?.[0] || 'dhpc5npmqkansx38uh18h3uwpdp6g9ukozr
 const CORESTORE = cmd.flags.externalCorestore && path.join(os.homedir(), '.pear-archdump', `${RUNTIMES_DRIVE_KEY}`)
 
 const ROOT = global.Pear ? path.join(new URL(global.Pear.config.applink).pathname, __dirname) : __dirname
-const ADDON_HOST = require.addon?.host || platform + '-' + arch
+let ADDON_HOST = require.addon?.host || platform + '-' + arch
+if (ADDON_HOST === 'win32-arm64') ADDON_HOST = 'win32-x64' // TODO: support runtime for Windows ARM to avoid emulation
 const PEAR = path.join(ROOT, '..', 'pear')
 const SWAP = path.join(ROOT, '..')
 const HOST = path.join(SWAP, 'by-arch', ADDON_HOST)


### PR DESCRIPTION
EDIT: found out the easiest solution is simply to install x64-Node and it will run just fine on Windows ARM VM.

Leaving below the reasoning behind this PR to understand if this is still relevant for pear-next, maybe needs a warning when bootstrap fails due this.

---

Fact: `main` and `pear-next` bootstrap fail silently when the system uses arm64-NodeJS on Windows (which-runtime `arch: 'arm64'`)

---

`npx pear`

<img width="920" alt="image" src="https://github.com/user-attachments/assets/c7949ee5-8a73-4b6d-a13b-08b3fefa6c4a" />

( `by-arch/` never gets populated )

---

Prod Keet (`https://keet.io/downloads/2.5.0/Keet.msix`) works without any change (doesn't rely on system node/bare/npm)

<img width="471" alt="image" src="https://github.com/user-attachments/assets/84ff2164-9776-4095-87e9-6329484c8b1f" />

---

Patching bootstrap (this PR) fixed my localdev work on the `main` branch:

<img width="1273" alt="image" src="https://github.com/user-attachments/assets/2bfd5f75-d8e3-446d-9c73-430f77c5fe72" />

