### PR TITLE
[pear-next] CLI `$ pear data assets`

### DIFF
--- a/cmd/data.js
+++ b/cmd/data.js
@@ -57,7 +57,6 @@ const assetsOutput = (assets) => {
 
 const output = outputter('data', {
   apps: (result) => appsOutput(result),
-  link: (result) => appsOutput([result]),
   dht: (result) => dhtOutput(result),
   gc: (result) => gcOutput(result),
   manifest: (result) => manifestOutput(result),
@@ -78,10 +77,8 @@ class Data {
     if (link) {
       const parsed = plink.parse(link)
       if (!parsed) throw ERR_INVALID_INPUT(`Link "${link}" is not a valid key`)
-      await output(json, this.ipc.data({ resource: 'link', secrets, link }), { tag: 'link' }, this.ipc)
-    } else {
-      await output(json, this.ipc.data({ resource: 'apps', secrets }), { tag: 'apps' }, this.ipc)
     }
+    await output(json, this.ipc.data({ resource: 'apps', secrets, link }), { tag: 'apps' }, this.ipc)
   }
 
   async dht (cmd) {
@@ -105,6 +102,11 @@ class Data {
   async assets (cmd) {
     const { command } = cmd
     const { json } = command.parent.flags
-    await output(json, this.ipc.data({ resource: 'assets' }), { tag: 'assets' }, this.ipc)
+    const link = command.args.link
+    if (link) {
+      const parsed = plink.parse(link)
+      if (!parsed) throw ERR_INVALID_INPUT(`Link "${link}" is not a valid key`)
+    }
+    await output(json, this.ipc.data({ resource: 'assets', link }), { tag: 'assets' }, this.ipc)
   }
 }

--- a/cmd/data.js
+++ b/cmd/data.js
@@ -44,12 +44,24 @@ const manifestOutput = (manifest) => {
   return `version: ${ansi.bold(manifest.version)}\n`
 }
 
+const assetsOutput = (assets) => {
+  if (!assets.length) return placeholder
+  let out = ''
+  for (const asset of assets) {
+    out += `- ${ansi.bold(asset.link)}\n`
+    out += `${padding}path: ${ansi.dim(asset.path)}\n`
+    out += '\n'
+  }
+  return out
+}
+
 const output = outputter('data', {
   apps: (result) => appsOutput(result),
   link: (result) => appsOutput([result]),
   dht: (result) => dhtOutput(result),
   gc: (result) => gcOutput(result),
-  manifest: (result) => manifestOutput(result)
+  manifest: (result) => manifestOutput(result),
+  assets: (result) => assetsOutput(result)
 })
 
 module.exports = (ipc) => new Data(ipc)
@@ -88,5 +100,11 @@ class Data {
     const { command } = cmd
     const { json } = command.parent.flags
     await output(json, this.ipc.data({ resource: 'manifest' }), { tag: 'manifest' }, this.ipc)
+  }
+
+  async assets (cmd) {
+    const { command } = cmd
+    const { json } = command.parent.flags
+    await output(json, this.ipc.data({ resource: 'assets' }), { tag: 'assets' }, this.ipc)
   }
 }

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -248,7 +248,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     command('dht', summary('DHT known-nodes cache'), (cmd) => runners.data(ipc).dht(cmd)),
     command('gc', summary('Garbage collection records'), (cmd) => runners.data(ipc).gc(cmd)),
     command('manifest', summary('database internal versioning'), (cmd) => runners.data(ipc).manifest(cmd)),
-    command('assets', summary('Assets in the filesystem'), (cmd) => runners.data(ipc).assets(cmd)),
+    command('assets', summary('on-disk assets for app'), (cmd) => runners.data(ipc).assets(cmd)),
     flag('--secrets', 'Show sensitive information'),
     flag('--json', 'Newline delimited JSON output'),
     () => { console.log(data.help()) }

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -248,6 +248,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     command('dht', summary('DHT known-nodes cache'), (cmd) => runners.data(ipc).dht(cmd)),
     command('gc', summary('Garbage collection records'), (cmd) => runners.data(ipc).gc(cmd)),
     command('manifest', summary('database internal versioning'), (cmd) => runners.data(ipc).manifest(cmd)),
+    command('assets', summary('Assets in the filesystem'), (cmd) => runners.data(ipc).assets(cmd)),
     flag('--secrets', 'Show sensitive information'),
     flag('--json', 'Newline delimited JSON output'),
     () => { console.log(data.help()) }

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -248,7 +248,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     command('dht', summary('DHT known-nodes cache'), (cmd) => runners.data(ipc).dht(cmd)),
     command('gc', summary('Garbage collection records'), (cmd) => runners.data(ipc).gc(cmd)),
     command('manifest', summary('Database internal versioning'), (cmd) => runners.data(ipc).manifest(cmd)),
-    command('assets', summary('On-disk assets for app'), (cmd) => runners.data(ipc).assets(cmd)),
+    command('assets', summary('On-disk assets for app'), arg('[link]', 'Filter by link'), (cmd) => runners.data(ipc).assets(cmd)),
     flag('--secrets', 'Show sensitive information'),
     flag('--json', 'Newline delimited JSON output'),
     () => { console.log(data.help()) }

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -247,8 +247,8 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     command('apps', summary('Installed apps'), arg('[link]', 'Filter by link'), (cmd) => runners.data(ipc).apps(cmd)),
     command('dht', summary('DHT known-nodes cache'), (cmd) => runners.data(ipc).dht(cmd)),
     command('gc', summary('Garbage collection records'), (cmd) => runners.data(ipc).gc(cmd)),
-    command('manifest', summary('database internal versioning'), (cmd) => runners.data(ipc).manifest(cmd)),
-    command('assets', summary('on-disk assets for app'), (cmd) => runners.data(ipc).assets(cmd)),
+    command('manifest', summary('Database internal versioning'), (cmd) => runners.data(ipc).manifest(cmd)),
+    command('assets', summary('On-disk assets for app'), (cmd) => runners.data(ipc).assets(cmd)),
     flag('--secrets', 'Show sensitive information'),
     flag('--json', 'Newline delimited JSON output'),
     () => { console.log(data.help()) }

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -119,6 +119,13 @@ module.exports = class Model {
     return asset
   }
 
+  async getAsset (link) {
+    const get = { link }
+    LOG.trace('db', 'GET', '@pear/asset', get)
+    const asset = await this.db.get('@pear/asset', get)
+    return asset
+  }
+
   async allAssets () {
     LOG.trace('db', 'FIND', '@pear/asset')
     return await this.db.find('@pear/asset').toArray()

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -119,6 +119,11 @@ module.exports = class Model {
     return asset
   }
 
+  async allAssets () {
+    LOG.trace('db', 'FIND', '@pear/asset')
+    return await this.db.find('@pear/asset').toArray()
+  }
+
   async getDhtNodes () {
     LOG.trace('db', 'GET', '@pear/dht', '[nodes]')
     return (await this.db.get('@pear/dht'))?.nodes || []

--- a/subsystems/sidecar/ops/data.js
+++ b/subsystems/sidecar/ops/data.js
@@ -8,15 +8,15 @@ module.exports = class Data extends Opstream {
 
   async #op ({ resource, secrets, link }) {
     if (resource === 'apps') {
-      let bundles = await this.sidecar.model.allBundles()
+      let bundles
+      if (link) {
+        const bundle = await this.sidecar.model.getBundle(link)
+        bundles = bundle ? [bundle] : []
+      } else {
+        bundles = await this.sidecar.model.allBundles()
+      }
       if (!secrets) bundles = bundles.map(({ encryptionKey, ...rest }) => rest)
       this.push({ tag: 'apps', data: bundles })
-    }
-
-    if (resource === 'link') {
-      const bundle = await this.sidecar.model.getBundle(link)
-      if (bundle && !secrets) bundle.encryptionKey = undefined
-      this.push({ tag: 'link', data: bundle })
     }
 
     if (resource === 'dht') {
@@ -35,7 +35,13 @@ module.exports = class Data extends Opstream {
     }
 
     if (resource === 'assets') {
-      const assets = await this.sidecar.model.allAssets()
+      let assets
+      if (link) {
+        const asset = await this.sidecar.model.getAsset(link)
+        assets = asset ? [asset] : []
+      } else {
+        assets = await this.sidecar.model.allAssets()
+      }
       this.push({ tag: 'assets', data: assets })
     }
   }

--- a/subsystems/sidecar/ops/data.js
+++ b/subsystems/sidecar/ops/data.js
@@ -33,5 +33,10 @@ module.exports = class Data extends Opstream {
       const manifest = await this.sidecar.model.getManifest()
       this.push({ tag: 'manifest', data: manifest })
     }
+
+    if (resource === 'assets') {
+      const assets = await this.sidecar.model.allAssets()
+      this.push({ tag: 'assets', data: assets })
+    }
   }
 }

--- a/test/01-smoke.test.js
+++ b/test/01-smoke.test.js
@@ -224,9 +224,9 @@ test('local app', async function ({ ok, is, teardown }) {
   is(versions.app.key, null, 'app key is null')
   await Helper.untilClose(run.pipe)
 
-  const data = await helper.data({ resource: 'link', link: tmpdir })
-  const dataResult = await Helper.pick(data, [{ tag: 'link' }])
-  const bundle = await dataResult.link
+  const data = await helper.data({ resource: 'apps', link: tmpdir })
+  const dataResult = await Helper.pick(data, [{ tag: 'apps' }])
+  const bundle = (await dataResult.apps)[0]
 
   is(bundle.link, pathToFileURL(tmpdir).href, 'href of the directory is the app bundle key')
   ok(bundle.appStorage.includes('by-random'), 'application by storage has been generate randomly and persisted')

--- a/test/09-data.test.js
+++ b/test/09-data.test.js
@@ -46,18 +46,18 @@ test('pear data', async function ({ ok, is, plan, comment, timeout, teardown }) 
   is(typeof bundles[0].appStorage, 'string', 'Field appStorage is a string')
 
   comment('pear data apps [link]')
-  data = await helper.data({ resource: 'link', link })
-  result = await Helper.pick(data, [{ tag: 'link' }])
-  let bundle = await result.link
+  data = await helper.data({ resource: 'apps', link })
+  result = await Helper.pick(data, [{ tag: 'apps' }])
+  let bundle = (await result.apps)[0]
   ok(bundle.encryptionKey === undefined, 'Encryption key is hidden without --secrets')
   ok(bundle.link.startsWith('pear://'), 'Link starts with pear://')
   is(bundle.link, link, 'Link matches to the one just created')
   is(typeof bundle.appStorage, 'string', 'Field appStorage is a string')
 
   comment('pear data --secrets apps [link]')
-  data = await helper.data({ resource: 'link', link, secrets: true })
-  result = await Helper.pick(data, [{ tag: 'link' }])
-  bundle = await result.link
+  data = await helper.data({ resource: 'apps', link, secrets: true })
+  result = await Helper.pick(data, [{ tag: 'apps' }])
+  bundle = (await result.apps)[0]
   is(bundle.encryptionKey.toString('hex'), ek.toString('hex'), 'Encryption key from bundle matches')
   ok(bundle.link.startsWith('pear://'), 'Link starts with pear://')
   is(bundle.link, link, 'Link matches to the one just created')


### PR DESCRIPTION
Sub-task: refactored "link" resource to be unified with "apps" because they are the same thing, link is not a resource in the database so it was misleading.

---

`[link]` filter param:

```
$ pear data assets pear://0.2648.yceb7sjhgfzsnza7oc38hy3oxu9dhnywi3mzxdm9ubc48kjnxqgo

- pear://0.2648.yceb7sjhgfzsnza7oc38hy3oxu9dhnywi3mzxdm9ubc48kjnxqgo
    path: /Users/user/holepunch-next/pear/pear/assets/fd518df78e738be377b680243a82e0ac


✔ Success
```

---

List all assets:

<img width="903" alt="image" src="https://github.com/user-attachments/assets/68d0717d-f5b3-4118-95df-9a0b96a746f6" />

---

--help

<img width="482" alt="image" src="https://github.com/user-attachments/assets/01a73148-078e-48ed-9e35-f4f52b1004b0" />

---

<img width="775" alt="image" src="https://github.com/user-attachments/assets/279181a2-af4f-4523-946c-99a5ceb5aced" />
