### PR TITLE
[pear-next] Fix paparam syntax for `ms` arg in `pear gc interfaces --age <ms>`

### DIFF
--- a/cmd/index.js
+++ b/cmd/index.js
@@ -230,7 +230,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     summary('Advanced. Clear dangling resources'),
     command('releases', summary('Clear inactive releases'), (cmd) => runners.gc(ipc).releases(cmd)),
     command('sidecars', summary('Clear running sidecars'), (cmd) => runners.gc(ipc).sidecars(cmd)),
-    command('interfaces', flag('--age ms', 'GC if mtime exceeds. Default 2.592e9ms (30 days)'), summary('Clear unused interfaces'), (cmd) => runners.gc(ipc).interfaces(cmd)),
+    command('interfaces', flag('--age <ms>', 'GC if mtime exceeds. Default 2.592e9ms (30 days)'), summary('Clear unused interfaces'), (cmd) => runners.gc(ipc).interfaces(cmd)),
     flag('--json', 'Newline delimited JSON output'),
     () => { console.log(gc.help()) }
   )


### PR DESCRIPTION
`ms` was not correctly parsed when not defined as required or optional in `paparam`'s syntax.