### PR TITLE
[pear-next] `$ pear gc assets [link]`

### DIFF
--- a/cmd/gc.js
+++ b/cmd/gc.js
@@ -1,5 +1,7 @@
 'use strict'
-const { outputter } = require('pear-api/terminal')
+const plink = require('pear-api/link')
+const { outputter, confirm, ansi } = require('pear-api/terminal')
+const { ERR_INVALID_INPUT } = require('pear-api/errors')
 
 const output = outputter('gc', {
   remove: ({ resource, id }) => `Removed ${resource.slice(0, -1)} '${id}'`,
@@ -32,6 +34,17 @@ class GC {
   async assets (cmd) {
     const { command } = cmd
     const link = command.args.link
+    if (link) {
+      const parsed = plink.parse(link)
+      if (!parsed) throw ERR_INVALID_INPUT(`Link "${link}" is not a valid key`)
+    }
+    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} assets will be permanently removed and cannot be recovered. To confirm type "DELETE"\n\n`
+    const target = link || 'all assets'
+    const ask = `Delete ${target}`
+    const delim = '?'
+    const validation = v => v === 'DELETE'
+    const msg = '\n' + ansi.cross + ' type uppercase DELETE to confirm\n'
+    await confirm(dialog, ask, delim, validation, msg)
     return this.#op(cmd, { link })
   }
 }

--- a/cmd/gc.js
+++ b/cmd/gc.js
@@ -38,7 +38,7 @@ class GC {
       const parsed = plink.parse(link)
       if (!parsed) throw ERR_INVALID_INPUT(`Link "${link}" is not a valid key`)
     }
-    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} assets will be permanently removed and cannot be recovered. To confirm type "DELETE"\n\n`
+    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} synced assets will be permanently removed and cannot be recovered. To confirm type "DELETE"\n\n`
     const target = link || 'all assets'
     const ask = `Delete ${target}`
     const delim = '?'

--- a/cmd/gc.js
+++ b/cmd/gc.js
@@ -38,7 +38,7 @@ class GC {
       const parsed = plink.parse(link)
       if (!parsed) throw ERR_INVALID_INPUT(`Link "${link}" is not a valid key`)
     }
-    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} synced assets will be permanently removed and cannot be recovered. To confirm type "DELETE"\n\n`
+    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} synced assets will be permanently removed. To confirm type "DELETE"\n\n`
     const target = link || 'all assets'
     const ask = `Delete ${target}`
     const delim = '?'

--- a/cmd/gc.js
+++ b/cmd/gc.js
@@ -40,7 +40,7 @@ class GC {
     }
     const dialog = ansi.warning + `  ${ansi.bold('WARNING')} synced assets will be removed from disk. To confirm type "CLEAR"\n\n`
     const target = link || 'all assets'
-    const ask = `Clear ${ansi.dim(target)}`
+    const ask = `Clear ${target}`
     const delim = '?'
     const validation = v => v === 'CLEAR'
     const msg = '\n' + ansi.cross + ' type uppercase CLEAR to confirm\n'

--- a/cmd/gc.js
+++ b/cmd/gc.js
@@ -38,12 +38,12 @@ class GC {
       const parsed = plink.parse(link)
       if (!parsed) throw ERR_INVALID_INPUT(`Link "${link}" is not a valid key`)
     }
-    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} synced assets will be permanently removed. To confirm type "DELETE"\n\n`
+    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} synced assets will be removed from disk. To confirm type "CLEAR"\n\n`
     const target = link || 'all assets'
-    const ask = `Delete ${target}`
+    const ask = `Clear ${ansi.dim(target)}`
     const delim = '?'
-    const validation = v => v === 'DELETE'
-    const msg = '\n' + ansi.cross + ' type uppercase DELETE to confirm\n'
+    const validation = v => v === 'CLEAR'
+    const msg = '\n' + ansi.cross + ' type uppercase CLEAR to confirm\n'
     await confirm(dialog, ask, delim, validation, msg)
     return this.#op(cmd, { link })
   }

--- a/cmd/gc.js
+++ b/cmd/gc.js
@@ -5,7 +5,7 @@ const { ERR_INVALID_INPUT } = require('pear-api/errors')
 
 const output = outputter('gc', {
   remove: ({ resource, id }) => `Removed ${resource.slice(0, -1)} '${id}'`,
-  complete: ({ resource, count }) => { return count > 0 ? `Total ${resource}s removed: ${count}` : `No ${resource} removed` },
+  complete: ({ resource, count }) => { return count > 0 ? `Total ${resource} removed: ${count}` : `No ${resource} removed` },
   error: ({ code, message, stack }) => `GC Error (code: ${code || 'none'}) ${message} ${stack}`
 })
 
@@ -38,7 +38,7 @@ class GC {
       const parsed = plink.parse(link)
       if (!parsed) throw ERR_INVALID_INPUT(`Link "${link}" is not a valid key`)
     }
-    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} synced assets will be removed from disk. To confirm type "CLEAR"\n\n`
+    const dialog = ansi.warning + `  ${ansi.bold('WARNING')} synced assets will be cleared from disk. To confirm type "CLEAR"\n\n`
     const target = link || 'all assets'
     const ask = `Clear ${target}`
     const delim = '?'

--- a/cmd/gc.js
+++ b/cmd/gc.js
@@ -29,7 +29,9 @@ class GC {
     return this.#op(cmd, { pid: Bare.pid })
   }
 
-  async interfaces (cmd) {
-    return this.#op(cmd, { age: cmd.flags.age })
+  async assets (cmd) {
+    const { command } = cmd
+    const link = command.args.link
+    return this.#op(cmd, { link })
   }
 }

--- a/cmd/gc.js
+++ b/cmd/gc.js
@@ -42,7 +42,7 @@ class GC {
     const target = link || 'all assets'
     const ask = `Clear ${target}`
     const delim = '?'
-    const validation = v => v === 'CLEAR'
+    const validation = (v) => v === 'CLEAR'
     const msg = '\n' + ansi.cross + ' type uppercase CLEAR to confirm\n'
     await confirm(dialog, ask, delim, validation, msg)
     return this.#op(cmd, { link })

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -230,7 +230,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     summary('Advanced. Clear dangling resources'),
     command('releases', summary('Clear inactive releases'), (cmd) => runners.gc(ipc).releases(cmd)),
     command('sidecars', summary('Clear running sidecars'), (cmd) => runners.gc(ipc).sidecars(cmd)),
-    command('assets', summary('Clear allocated assets'), arg('[link]', 'Filter by link'), (cmd) => runners.gc(ipc).assets(cmd)),
+    command('assets', summary('Clear synced assets'), arg('[link]', 'Filter by link'), (cmd) => runners.gc(ipc).assets(cmd)),
     flag('--json', 'Newline delimited JSON output'),
     () => { console.log(gc.help()) }
   )

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -230,7 +230,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
     summary('Advanced. Clear dangling resources'),
     command('releases', summary('Clear inactive releases'), (cmd) => runners.gc(ipc).releases(cmd)),
     command('sidecars', summary('Clear running sidecars'), (cmd) => runners.gc(ipc).sidecars(cmd)),
-    command('interfaces', flag('--age ms', 'GC if mtime exceeds. Default 2.592e9ms (30 days)'), summary('Clear unused interfaces'), (cmd) => runners.gc(ipc).interfaces(cmd)),
+    command('assets', summary('Clear allocated assets'), arg('[link]', 'Filter by link'), (cmd) => runners.gc(ipc).assets(cmd)),
     flag('--json', 'Newline delimited JSON output'),
     () => { console.log(gc.help()) }
   )

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -340,7 +340,7 @@ class Sidecar extends ReadyResource {
 
   run (params, client) { return new ops.Run(params, client, this) }
 
-  gc (params, client) { return new ops.GC(params, client) }
+  gc (params, client) { return new ops.GC(params, client, this) }
 
   touch (params, client) { return new ops.Touch(params, client, this) }
 

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -129,13 +129,14 @@ module.exports = class Model {
   }
 
   async removeAsset (link) {
+    const get = { link }
     const tx = await this.lock.enter()
-    LOG.trace('db', 'GET', '@pear/asset', { link })
-    const asset = await tx.get('@pear/asset', { link })
+    LOG.trace('db', 'GET', '@pear/asset', get)
+    const asset = await tx.get('@pear/asset', get)
     if (asset) {
       if (asset.path) await fs.promises.rm(asset.path, { recursive: true, force: true })
-      LOG.trace('db', 'DELETE', '@pear/asset', asset)
-      await tx.delete('@pear/asset', asset)
+      LOG.trace('db', 'DELETE', '@pear/asset', get)
+      await tx.delete('@pear/asset', get)
     }
     await this.lock.exit()
     return asset

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -128,23 +128,17 @@ module.exports = class Model {
     return await this.db.find('@pear/asset').toArray()
   }
 
-  async removeAssets ({ link }) {
+  async removeAsset (link) {
     const tx = await this.lock.enter()
-    let assets = []
-    if (link) {
-      const asset = await tx.get('@pear/asset', { link })
-      LOG.trace('db', 'GET', '@pear/asset', link)
-      assets.push(asset)
-    } else {
-      LOG.trace('db', 'FIND', '@pear/asset')
-      assets = await tx.find('@pear/asset').toArray()
-    }
-    for (const asset of assets) {
-      await fs.promises.rm(asset.path, { recursive: true, force: true })
+    LOG.trace('db', 'GET', '@pear/asset', { link })
+    const asset = await tx.get('@pear/asset', { link })
+    if (asset) {
+      if (asset.path) await fs.promises.rm(asset.path, { recursive: true, force: true })
       LOG.trace('db', 'DELETE', '@pear/asset', asset)
       await tx.delete('@pear/asset', asset)
     }
     await this.lock.exit()
+    return asset
   }
 
   async getDhtNodes () {

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -143,7 +143,7 @@ module.exports = class Model {
 
   async removeAllAssets () {
     const tx = await this.lock.enter()
-    const assets = await this.db.find('@pear/asset').toArray()
+    const assets = await tx.find('@pear/asset').toArray()
     for (const asset of assets) {
       await fs.promises.rm(asset.path, { recursive: true, force: true })
       LOG.trace('db', 'DELETE', '@pear/asset', asset)

--- a/subsystems/sidecar/lib/model.js
+++ b/subsystems/sidecar/lib/model.js
@@ -128,22 +128,17 @@ module.exports = class Model {
     return await this.db.find('@pear/asset').toArray()
   }
 
-  async removeAsset (link) {
+  async removeAssets ({ link }) {
     const tx = await this.lock.enter()
-    const get = { link }
-    LOG.trace('db', 'GET', '@pear/asset', get)
-    const asset = await tx.get('@pear/asset', get)
-    if (asset) {
-      await fs.promises.rm(asset.path, { recursive: true, force: true })
-      LOG.trace('db', 'DELETE', '@pear/asset', asset)
-      await tx.delete('@pear/asset', asset)
+    let assets = []
+    if (link) {
+      const asset = await tx.get('@pear/asset', { link })
+      LOG.trace('db', 'GET', '@pear/asset', link)
+      assets.push(asset)
+    } else {
+      LOG.trace('db', 'FIND', '@pear/asset')
+      assets = await tx.find('@pear/asset').toArray()
     }
-    await this.lock.exit()
-  }
-
-  async removeAllAssets () {
-    const tx = await this.lock.enter()
-    const assets = await tx.find('@pear/asset').toArray()
     for (const asset of assets) {
       await fs.promises.rm(asset.path, { recursive: true, force: true })
       LOG.trace('db', 'DELETE', '@pear/asset', asset)

--- a/subsystems/sidecar/ops/gc.js
+++ b/subsystems/sidecar/ops/gc.js
@@ -111,10 +111,6 @@ module.exports = class GC extends Opstream {
 
   async assets ({ link }) {
     await this.sidecar.ready()
-    if (link) {
-      await this.sidecar.model.removeAsset(link)
-    } else {
-      await this.sidecar.model.removeAllAssets()
-    }
+    await this.sidecar.model.removeAssets(link)
   }
 }

--- a/subsystems/sidecar/ops/gc.js
+++ b/subsystems/sidecar/ops/gc.js
@@ -22,7 +22,7 @@ module.exports = class GC extends Opstream {
     const { resource } = this
     if (resource === 'releases') return this.releases(data)
     if (resource === 'sidecars') return this.sidecars(data)
-    if (resource === 'interfaces') return this.interfaces(data)
+    if (resource === 'assets') return this.assets(data)
     throw ERR_INVALID_GC_RESOURCE('Invalid resource to gc: ' + resource)
   }
 
@@ -109,33 +109,6 @@ module.exports = class GC extends Opstream {
     })
   }
 
-  async interfaces ({ age = 2.592e9 }) { // default age, 30 days
-    const interfaces = path.join(PLATFORM_DIR, 'interfaces')
-    await fs.promises.mkdir(interfaces, { recursive: true })
-
-    const runtimes = await fs.promises.opendir(interfaces)
-
-    const { resource } = this
-    const now = Date.now()
-
-    try {
-      for await (const runtime of runtimes) {
-        if (runtime.isDirectory() === false) continue
-        const semvers = await fs.promises.opendir(runtime)
-        for await (const entry of semvers) {
-          if (entry.isDirectory() === false) continue
-          const version = path.join(runtime, entry.name)
-          const stats = await fs.promises.stat(version)
-          const delta = now - stats.mtimeMs
-          if (delta > age) {
-            this.push({ tag: 'remove', data: { resource, id: version } })
-            await fs.promises.rm(version, { recursive: true, force: true })
-          }
-        }
-      }
-    } catch (err) {
-      if (err.code === 'ENOENT' || err.code === 'EBUSY') return
-      throw err
-    }
+  async assets ({ link }) {
   }
 }

--- a/subsystems/sidecar/ops/gc.js
+++ b/subsystems/sidecar/ops/gc.js
@@ -110,5 +110,11 @@ module.exports = class GC extends Opstream {
   }
 
   async assets ({ link }) {
+    await this.sidecar.ready()
+    if (link) {
+      await this.sidecar.model.removeAsset(link)
+    } else {
+      await this.sidecar.model.removeAllAssets()
+    }
   }
 }


### PR DESCRIPTION
* `$ pear gc` -> print help
* `$ pear gc assets` -> remove all (prompt to confirm)
* `$ pear gc assets [link]` -> only one

---

* Directory is rm'd (forced, fine with not existing)
* Removes entry from hyperdb

---

```
$ pear gc

  Commands:
    releases    Clear inactive releases
    sidecars    Clear running sidecars
    assets      Clear synced assets
```

<img width="890" alt="image" src="https://github.com/user-attachments/assets/4c47c4b9-fab0-4aa9-a65d-55be120f17aa" />

---

`$ pear data assets` + `$ pear gc assets [LINK]`

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/d5e8656f-5a98-4bb1-b280-b9e384b695bc" />

---

Sub-task

* Fixed plural

<img width="683" alt="Screenshot 2025-06-19 at 18 50 38" src="https://github.com/user-attachments/assets/b332025a-8ee0-487f-82e3-c389cbc543df" />

---

Note:

`pear gc releases` is not working in pear-next:

<img width="1120" alt="Screenshot 2025-06-19 at 19 43 57" src="https://github.com/user-attachments/assets/f92d67e0-9514-49bd-a76b-0f876dd368ed" />

