### PR TITLE
terminate unresponsive apps on deathclock

### DIFF
--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -1014,6 +1014,13 @@ class Sidecar extends ReadyResource {
     }
   }
 
+  _terminateUnresponsiveApps () {
+    for (const app of this.apps) {
+      if (!app.state.pid) continue
+      os.kill(app.state.pid, 'SIGKILL')
+    }
+  }
+
   deathClock (ms = 20000) {
     clearTimeout(this.bailout)
     this.bailout = setTimeout(async () => {
@@ -1026,6 +1033,7 @@ class Sidecar extends ReadyResource {
           LOG.error('sidecar', err)
         }
       }
+      this._terminateUnresponsiveApps()
       LOG.error('internal', 'DEATH CLOCK TRIGGERED, FORCE KILLING. EXIT CODE 124')
       Bare.exit(124) // timeout
     }, ms).unref()

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -1017,6 +1017,7 @@ class Sidecar extends ReadyResource {
   _terminateUnresponsiveApps () {
     for (const app of this.apps) {
       if (!app.state.pid) continue
+      LOG.info('sidecar', `Killing unresponsive app with PID ${app.state.pid}`)
       os.kill(app.state.pid, 'SIGKILL')
     }
   }

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -1014,14 +1014,6 @@ class Sidecar extends ReadyResource {
     }
   }
 
-  _terminateUnresponsiveApps () {
-    for (const app of this.apps) {
-      if (!app.state.pid) continue
-      LOG.info('sidecar', `Killing unresponsive app with PID ${app.state.pid}`)
-      os.kill(app.state.pid, 'SIGKILL')
-    }
-  }
-
   deathClock (ms = 20000) {
     clearTimeout(this.bailout)
     this.bailout = setTimeout(async () => {
@@ -1034,7 +1026,14 @@ class Sidecar extends ReadyResource {
           LOG.error('sidecar', err)
         }
       }
-      this._terminateUnresponsiveApps()
+
+      // terminate any remaining unresponsive processes
+      for (const app of this.apps) {
+        if (!app.state.pid) continue
+        LOG.info('sidecar', `Killing unresponsive app with PID ${app.state.pid}`)
+        os.kill(app.state.pid, 'SIGKILL')
+      }
+
       LOG.error('internal', 'DEATH CLOCK TRIGGERED, FORCE KILLING. EXIT CODE 124')
       Bare.exit(124) // timeout
     }, ms).unref()


### PR DESCRIPTION
### Description
This pull request adds functionality to terminate unresponsive apps after `sidecar.close` is called.  

### Details
- After calling `closeClients`, the `sidecar.apps` array should be empty.  
- If `app` instances remain in the array after the `deathclock` expires, it indicates that the app or worker is unresponsive.  
- This issue may be caused by a faulty teardown + restart sequence (as reported by Keet users in recent weeks).  
- To address this, the PR sends a `SIGKILL` signal to unresponsive processes right before force-closing the sidecar (which would otherwise hang due to the unresponsive app).  
