### PR TITLE
[pear-next] reset deprecation notice

### DIFF
--- a/cmd/index.js
+++ b/cmd/index.js
@@ -198,6 +198,7 @@ module.exports = async (ipc, argv = Bare.argv.slice(1)) => {
 
   const reset = hiddenCommand(
     'reset',
+    arg('[link]'),
     () => {
       console.log(`${ansi.warning} Deprecated. Use ${ansi.bold('pear drop app <link>')} instead.\n`)
       console.log(drop.help())


### PR DESCRIPTION
before

<img width="793" height="71" alt="image" src="https://github.com/user-attachments/assets/5cba3e2c-4a20-43b8-923b-069010e16250" />


after

<img width="786" height="76" alt="image" src="https://github.com/user-attachments/assets/39ff6c42-f6b6-4781-80ed-87f9d86e087d" />
