### PR TITLE
open inspector when running in dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pear Runtime Changelog
 
+## v2.2.5
+
+### Improvements
+
+* Internal - added progress to installer in new launch dynamic library
+
 ## v2.2.4
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pear Runtime Changelog
 
+## v2.2.6
+
+### Fixes
+
+* Fixes - Fixed hyperswarm connectivity
+
 ## v2.2.5
 
 ### Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Pear Runtime Changelog
 
+## v2.2.4
+
+### Improvements
+
+* Internal - dependencies bump
+
 ## v2.2.3
 
 ### Fixes

--- a/cmd/run.js
+++ b/cmd/run.js
@@ -246,6 +246,18 @@ module.exports = (ipc) =>
       })
     })
 
+    // open the inspector when in devmode
+    // (except if we're opening the pear://runtime app to avoid loop)
+    const PEAR_RUNTIME_KEY = constants.ALIASES.runtime.toString('hex')
+
+    if (flags.dev && key !== PEAR_RUNTIME_KEY) {
+      const inspectorKey = (await ipc.inspect()).toString('hex')
+      daemon(constants.RUNTIME, [
+        'run',
+        `pear://${PEAR_RUNTIME_KEY}/dev?${inspectorKey}`
+      ])
+    }
+
     return new Promise((resolve) => global.Pear.teardown(resolve, Infinity))
   }
 

--- a/examples/desktop/index.js
+++ b/examples/desktop/index.js
@@ -2,6 +2,9 @@
 import Runtime from 'pear-electron'
 import Bridge from 'pear-bridge'
 import updates from 'pear-updates'
+import bareInspector from 'bare-inspector'
+import { Inspector } from 'pear-inspect'
+
 
 updates((update) => {
   console.log('Application update available:', update)
@@ -13,6 +16,10 @@ await bridge.ready()
 const runtime = new Runtime()
 const pipe = await runtime.start({ bridge })
 pipe.on('close', () => Pear.exit())
+
+const inspector = new Inspector({ inspector: bareInspector })
+const inspectorKey = await inspector.enable() // Pass the public key to the Session
+console.log(`Add this key to Pear Runtime: ${inspectorKey.toString('hex')}`)
 
 pipe.on('data', (data) => {
   const cmd = Buffer.from(data).toString()

--- a/examples/desktop/package.json
+++ b/examples/desktop/package.json
@@ -18,12 +18,14 @@
     }
   },
   "devDependencies": {
+    "bare-inspector": "^5.0.0",
     "brittle": "^3.0.0",
+    "pear-inspect": "^1.2.5",
     "pear-interface": "^1.0.0"
   },
   "dependencies": {
     "pear-bridge": "^1.2.1",
-    "pear-electron": "^1.7.20",
+    "pear-electron": "^1.7.25",
     "pear-messages": "^1.0.3",
     "pear-pipe": "^1.0.1",
     "pear-updates": "^1.0.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -252,6 +252,7 @@
       "resolved": "https://registry.npmjs.org/bare-bundle/-/bare-bundle-1.10.0.tgz",
       "integrity": "sha512-4LVlnJAHr00Hh6Vu6ZUJS38rcEtJT3b3vChXSsBsJ2mk1TN0lQ+gzd+Dw5L0aV7uqDZv84smuwW+O02X7PfDlw==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-buffer": "*",
         "bare-url": "*"
@@ -2072,6 +2073,7 @@
       "integrity": "sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1498,9 +1498,9 @@
       }
     },
     "node_modules/hyperswarm": {
-      "version": "4.15.1",
-      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.15.1.tgz",
-      "integrity": "sha512-J/ilPsnODBnJ31ErXU58Pzo+9fTHp+nVECOtoVJNulQ3KfjBXxhEHaefKeCxO4QWir742RcL6sFbLX3Ii5W2pA==",
+      "version": "4.15.3",
+      "resolved": "https://registry.npmjs.org/hyperswarm/-/hyperswarm-4.15.3.tgz",
+      "integrity": "sha512-0jiPwsWN8yv1MzVeazgpAHOu596MNRDjjfQ/SSDHBWXd4vVllDMmPsm1Jo0CcmHNFNWM3PDHk3lKIpMsjQKHqg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -731,9 +731,9 @@
       }
     },
     "node_modules/bare-subprocess": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.1.5.tgz",
-      "integrity": "sha512-hVOw9TJ5YnhnRD8fjaxNK7eTPfn4bR/uXHbD+4glmOvZzmmv+0twSUDSWFMYEBl5HBiurNVOUPZVuFrUyJvimg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/bare-subprocess/-/bare-subprocess-5.2.1.tgz",
+      "integrity": "sha512-uz/QxI4/hzoENrAzg8OFmpZHMHsyvrlETVV3Umewg0D/Vhk63TQE/5DRC1PQk3VzlpZoIeLhssSrBLyUo2QqAg==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-env": "^3.0.0",
@@ -1045,9 +1045,9 @@
       "license": "MIT"
     },
     "node_modules/corestore": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.6.1.tgz",
-      "integrity": "sha512-UpQNmirP0WK7sM4WsjbI/NdNLVYknTTu8u8fuJSsSvOeD5Tc8BkgrpRB5JhC828I2ENm2Y5WyhZtoFOFbZFckQ==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/corestore/-/corestore-7.7.0.tgz",
+      "integrity": "sha512-o1ZZFSjcUtIE6FFIsNJB3k1gv7AyVEYFmgFscdew6oSgSbWn4T5xBGT7L06lZNkwXTuYlsy56A+TPZvptLS4Rg==",
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.7",
@@ -1396,9 +1396,9 @@
       }
     },
     "node_modules/hypercore-storage": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-2.4.0.tgz",
-      "integrity": "sha512-atmeoByfvMKlEL2a/IHih2pV+1wUlsh0w8uHBDVsgiOlsQgF4AYCMXaHn+Dy+0IdYnfDRXNtTwQvkFZ1HfIh0Q==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/hypercore-storage/-/hypercore-storage-2.4.1.tgz",
+      "integrity": "sha512-VbdkPdj7iYkGX4mufUIPqmkk87PnJ5csi1Y5WGkMHAMneK/6ogIoGrBRmAH4jpFfagOsLnSN33rHmmq6OyM77g==",
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.7",
@@ -2067,9 +2067,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.1.tgz",
+      "integrity": "sha512-RWKXE4qB3u5Z6yz7omJkjWwmTfLdcbv44jUVHC5NpfXwFGzvpQM798FGv/6WNK879tc+Cn0AAyherCl1KjbyZQ==",
       "dev": true,
       "license": "MIT",
       "bin": {


### PR DESCRIPTION
Automatically opens the devtools/pear inspector via the link `pear://runtime/dev?<key>`

NOTE: testing requires staging the changes in the PR [here](https://github.com/holepunchto/pear-desktop/pull/47) via `pear stage dev`, seeding via `pear seed dev`, and then replacing the value for `PEAR_RUNTIME_KEY` with the resulting key.

- [ ] shut down daemon in tests