### PR TITLE
Omit ctrlTTY when interactive in init

### DIFF
--- a/cmd/init.js
+++ b/cmd/init.js
@@ -40,8 +40,9 @@ module.exports = async function init(cmd) {
   if (force) header += ansi.bold('FORCE MODE\n\n')
 
   try {
+    const outputOpts = yes ? false : { ctrlTTY: false }
     await output(
-      false,
+      outputOpts,
       await require('../init')(link, dir, {
         cwd,
         ipc,


### PR DESCRIPTION
`init` "steals" the cursor (caret) by taking over TTY. Fix by sending `ctrlTTY: false` when _not_ running `--yes`