### PR TITLE
Add regression test for init template defaults (#747)

### DIFF
--- a/test/14-init.test.js
+++ b/test/14-init.test.js
@@ -1,0 +1,58 @@
+'use strict'
+const test = require('brittle')
+const tmp = require('test-tmp')
+const fs = require('bare-fs')
+const path = require('bare-path')
+const os = require('bare-os')
+const Helper = require('./helper')
+const init = require('../init')
+
+test('init uses custom template defaults (#747)', async function ({
+  ok,
+  is,
+  plan,
+  teardown,
+  timeout
+}) {
+  timeout(180000)
+  plan(4)
+
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+
+  const templateDir = Helper.fixture('custom-template-defaults')
+  const outDir = await tmp()
+  teardown(() => Helper.gc(outDir))
+
+  const output = await init(templateDir, outDir, {
+    cwd: os.cwd(),
+    ipc: helper,
+    autosubmit: true,
+    defaults: { name: 'test-app', height: 540, width: 720 },
+    header: '',
+    force: true,
+    pkg: null
+  })
+
+  let success = false
+  for await (const msg of output) {
+    if (msg.tag === 'error') throw new Error(msg.data?.stack || msg.data?.message)
+    if (msg.tag === 'final') {
+      success = msg.data.success
+      break
+    }
+  }
+
+  ok(success, 'init completed successfully')
+
+  const raw = await fs.promises.readFile(path.join(outDir, 'package.json'), 'utf8')
+  const pkg = JSON.parse(raw)
+  is(pkg.name, 'test-app', 'name from passed defaults should be used')
+  is(
+    pkg.pear.gui.height,
+    1080,
+    'template default for height (1080) should be used, not hardcoded 540'
+  )
+  is(pkg.pear.gui.width, 800, 'template default for width (800) should be used, not hardcoded 720')
+})

--- a/test/fixtures/custom-template-defaults/_template.json
+++ b/test/fixtures/custom-template-defaults/_template.json
@@ -1,0 +1,22 @@
+{
+  "params": [
+    {
+      "name": "name",
+      "prompt": "name"
+    },
+    {
+      "name": "height",
+      "default": 1080,
+      "prompt": "height",
+      "validation": "(value) => Number.isInteger(+value)",
+      "msg": "must be an integer"
+    },
+    {
+      "name": "width",
+      "default": 800,
+      "prompt": "width",
+      "validation": "(value) => Number.isInteger(+value)",
+      "msg": "must be an integer"
+    }
+  ]
+}

--- a/test/fixtures/custom-template-defaults/package.json
+++ b/test/fixtures/custom-template-defaults/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "__name__",
+  "pear": {
+    "name": "__name__",
+    "type": "terminal",
+    "gui": {
+      "height": __height__,
+      "width": __width__
+    }
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -21,6 +21,7 @@ async function runTests() {
   await import('./11-touch.test.js')
   await import('./12-provision.test.js')
   await import('./13-shutdown.test.js')
+  await import('./14-init.test.js')
 
   test.resume()
 }


### PR DESCRIPTION
## Summary

- Adds a regression test ensuring custom `_template.json` defaults are used by `pear init`, not overridden by hardcoded fallback values
- Closes #747

## Context

Issue #747 reported that hardcoded `height: 540` and `width: 720` fallbacks in `cmd/init.js` were overriding custom template defaults. This was resolved during the v2 refactor — the `defaults` object now only contains `{ name }`, and `init/index.js` correctly prioritizes template defaults:

```js
defaults[prompt.name] = prompt.default ?? defaults[prompt.name]
```

However, no test existed to prevent regression. This PR adds one.

## What's included

- **Fixture** `test/fixtures/custom-template-defaults/` — a template with `height: 1080` and `width: 800` defaults
- **Test** `test/14-init.test.js` — calls `init()` with `autosubmit: true` and verifies:
  - `name` uses the passed default (`test-app`)
  - `height` uses the template default (`1080`, not `540`)
  - `width` uses the template default (`800`, not `720`)

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm test` passes with new test included