### PR TITLE
seed --json output fix invalid JSON stream

### DIFF
--- a/cmd/seed.js
+++ b/cmd/seed.js
@@ -322,7 +322,7 @@ module.exports = async function seed(cmd) {
   }
   const id = Bare.pid
   const { width } = stdio.size()
-  const appendMode = tty === false || !isTTY || !width
+  const appendMode = json || tty === false || !isTTY || !width
 
   const stats = new DictTable([
     {
@@ -365,7 +365,7 @@ module.exports = async function seed(cmd) {
     { appendMode }
   )
 
-  if (!json && !appendMode) {
+  if (!appendMode) {
     stdio.in?.setMode?.(bareTTY.constants.MODE_RAW)
     stdio.in?.on('data', (key) => {
       // Ctrl-C
@@ -393,7 +393,7 @@ module.exports = async function seed(cmd) {
 
   stats.set('link', link)
 
-  if (!json && !appendMode) {
+  if (!appendMode) {
     stdio.out.off('resize', resizeHandler)
     resizeHandler = () => {
       layout.print(stdio, { clearScrollback: true })
@@ -454,7 +454,7 @@ module.exports = async function seed(cmd) {
   })
 
   await output(
-    { json, ctrlTTY: !json && !appendMode },
+    { json, ctrlTTY: !appendMode },
     ipc.seed({
       id,
       link,

--- a/cmd/seed.js
+++ b/cmd/seed.js
@@ -365,7 +365,7 @@ module.exports = async function seed(cmd) {
     { appendMode }
   )
 
-  if (!appendMode) {
+  if (!json && !appendMode) {
     stdio.in?.setMode?.(bareTTY.constants.MODE_RAW)
     stdio.in?.on('data', (key) => {
       // Ctrl-C
@@ -393,7 +393,7 @@ module.exports = async function seed(cmd) {
 
   stats.set('link', link)
 
-  if (!appendMode) {
+  if (!json && !appendMode) {
     stdio.out.off('resize', resizeHandler)
     resizeHandler = () => {
       layout.print(stdio, { clearScrollback: true })
@@ -401,7 +401,7 @@ module.exports = async function seed(cmd) {
     stdio.out.on('resize', resizeHandler)
   }
 
-  layout.print(stdio, { clearScrollback: true })
+  if (!json) layout.print(stdio, { clearScrollback: true })
 
   const output = outputter('seed', {
     announced: () => {
@@ -454,7 +454,7 @@ module.exports = async function seed(cmd) {
   })
 
   await output(
-    { json, ctrlTTY: !appendMode },
+    { json, ctrlTTY: !json && !appendMode },
     ipc.seed({
       id,
       link,

--- a/subsystems/sidecar/ops/seed.js
+++ b/subsystems/sidecar/ops/seed.js
@@ -56,7 +56,7 @@ module.exports = class Seed extends Opstream {
     // not an app but a long running process, setting userData for restart recognition:
     client.userData = { state }
 
-    this.push({ tag: 'seeding', data: { key: link } })
+    this.push({ tag: 'seeding', data: { key: hypercoreid.encode(key), link } })
     await this.sidecar.ready()
 
     const corestore = this.sidecar.getCorestore()


### PR DESCRIPTION
1. Fix emit non-JSON lines


Before

`pear seed --json pear://keet`


<img width="1470" height="606" alt="image" src="https://github.com/user-attachments/assets/158d2a07-d3a0-4bef-a09d-f5dc0e0eb05a" />

---

After

<img width="1470" height="721" alt="image" src="https://github.com/user-attachments/assets/46b651b4-d00e-4d37-8c11-8795bff96940" />


---

2. `--json` only: fix `key` value, now it has two fields key(corrected) and link(original value)

Before

```
"data":{"key":"pear://keet"}}
```

After

```
"data: {"key":"oeeoz3w6fjjt7bym3ndpa6hhicm8f8naxyk11z4iypeoupn6jzpo", "link":"pear://keet"}}
```