### PR TITLE
pear seed: undefined guards

### DIFF
--- a/cmd/seed.js
+++ b/cmd/seed.js
@@ -446,9 +446,9 @@ module.exports = async function seed(cmd) {
         : `[ Peers ${ansi.green(peers)} ] [ ${ansi.up} ${ansi.green(byteSize(upload.totalBytes))} - ${ansi.green(`${byteSize(upload.speed)}/s`)} ] [ ${ansi.down} ${ansi.green(byteSize(download.totalBytes))} - ${ansi.green(`${byteSize(download.speed)}/s`)} ]`
 
       stats.update({
-        driveKey: hypercoreid.normalize(driveKey),
-        discoveryKey: hypercoreid.normalize(discoveryKey),
-        contentKey: hypercoreid.normalize(contentKey),
+        driveKey: driveKey && hypercoreid.normalize(driveKey),
+        discoveryKey: discoveryKey && hypercoreid.normalize(discoveryKey),
+        contentKey: contentKey && hypercoreid.normalize(contentKey),
         firewalled,
         natType,
         network

--- a/cmd/seed.js
+++ b/cmd/seed.js
@@ -446,8 +446,8 @@ module.exports = async function seed(cmd) {
         : `[ Peers ${ansi.green(peers)} ] [ ${ansi.up} ${ansi.green(byteSize(upload.totalBytes))} - ${ansi.green(`${byteSize(upload.speed)}/s`)} ] [ ${ansi.down} ${ansi.green(byteSize(download.totalBytes))} - ${ansi.green(`${byteSize(download.speed)}/s`)} ]`
 
       stats.update({
-        driveKey: driveKey && hypercoreid.normalize(driveKey),
-        discoveryKey: discoveryKey && hypercoreid.normalize(discoveryKey),
+        driveKey: hypercoreid.normalize(driveKey),
+        discoveryKey: hypercoreid.normalize(discoveryKey),
         contentKey: contentKey && hypercoreid.normalize(contentKey),
         firewalled,
         natType,


### PR DESCRIPTION
I got a scenario where the content-key starts as `undefined` when preemptively seeding a drive, causing a crash:

```js
Invalid Hypercore key
```

so this guard prevents the crash and keep it running until receiving a proper value, waiting for as long as needed, once ready it continues as expected:

<img width="847" height="312" alt="image" src="https://github.com/user-attachments/assets/be3ad445-a6bf-4657-b8f5-2fe4c69150f6" />
