### PR TITLE
Support win32-arm64

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "make:darwin-x64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host darwin-x64 --out ./by-arch/darwin-x64/bin scripts/standalone-entry.js && rm -f ./pear.dev && ln -s ./by-arch/darwin-x64/bin/pear ./pear.dev && chmod 775 ./pear.dev",
     "make:linux-arm64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host linux-arm64 --out ./by-arch/linux-arm64/bin scripts/standalone-entry.js && rm -f ./pear.dev && ln -s ./by-arch/linux-arm64/bin/pear ./pear.dev && chmod 775 ./pear.dev",
     "make:linux-x64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host linux-x64 --out ./by-arch/linux-x64/bin scripts/standalone-entry.js && rm -f ./pear.dev && ln -s ./by-arch/linux-x64/bin/pear ./pear.dev && chmod 775 ./pear.dev",
-    "make:win32-arm64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host win32-arm64 --out ./by-arch/win32-arm64/bin scripts/standalone-entry.js && node scripts/link-win32-dev.js arm64",
-    "make:win32-x64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host win32-x64 --out ./by-arch/win32-x64/bin scripts/standalone-entry.js && node scripts/link-win32-dev.js x64",
+    "make:win32-arm64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host win32-arm64 --out ./by-arch/win32-arm64/bin scripts/standalone-entry.js && node scripts/link-win32-dev.js",
+    "make:win32-x64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host win32-x64 --out ./by-arch/win32-x64/bin scripts/standalone-entry.js && node scripts/link-win32-dev.js",
     "hyperdb:build": "node scripts/build-hyperdb.js"
   },
   "author": "Holepunch",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "make:darwin-x64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host darwin-x64 --out ./by-arch/darwin-x64/bin scripts/standalone-entry.js && rm -f ./pear.dev && ln -s ./by-arch/darwin-x64/bin/pear ./pear.dev && chmod 775 ./pear.dev",
     "make:linux-arm64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host linux-arm64 --out ./by-arch/linux-arm64/bin scripts/standalone-entry.js && rm -f ./pear.dev && ln -s ./by-arch/linux-arm64/bin/pear ./pear.dev && chmod 775 ./pear.dev",
     "make:linux-x64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host linux-x64 --out ./by-arch/linux-x64/bin scripts/standalone-entry.js && rm -f ./pear.dev && ln -s ./by-arch/linux-x64/bin/pear ./pear.dev && chmod 775 ./pear.dev",
-    "make:win32-arm64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host win32-arm64 --out ./by-arch/win32-arm64/bin scripts/standalone-entry.js && node scripts/link-win32-dev.js",
-    "make:win32-x64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host win32-x64 --out ./by-arch/win32-x64/bin scripts/standalone-entry.js && node scripts/link-win32-dev.js",
+    "make:win32-arm64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host win32-arm64 --out ./by-arch/win32-arm64/bin scripts/standalone-entry.js && node scripts/link-win32-dev.js arm64",
+    "make:win32-x64": "bare-build --standalone --base . --name pear --description \"Pear runtime command line interface\" --host win32-x64 --out ./by-arch/win32-x64/bin scripts/standalone-entry.js && node scripts/link-win32-dev.js x64",
     "hyperdb:build": "node scripts/build-hyperdb.js"
   },
   "author": "Holepunch",

--- a/scripts/build-local-runtime.js
+++ b/scripts/build-local-runtime.js
@@ -8,11 +8,20 @@ const { spawnSync } = require('child_process')
 const root = path.resolve(__dirname, '..')
 const host = `${os.platform()}-${os.arch()}`
 const script = `make:${host}`
-const supported = new Set(['darwin-arm64', 'darwin-x64', 'linux-arm64', 'linux-x64', 'win32-x64'])
+const supported = new Set([
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64',
+  'linux-x64',
+  'win32-arm64',
+  'win32-x64'
+])
 
 if (!supported.has(host)) {
   console.error(`Unsupported platform/arch: ${host}`)
-  console.error('Supported targets: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-x64')
+  console.error(
+    'Supported targets: darwin-arm64, darwin-x64, linux-arm64, linux-x64, win32-arm64, win32-x64'
+  )
   process.exit(1)
 }
 

--- a/scripts/build-local-runtime.js
+++ b/scripts/build-local-runtime.js
@@ -25,12 +25,14 @@ if (!supported.has(host)) {
   process.exit(1)
 }
 
-const npmCmd = os.platform() === 'win32' ? 'npm.cmd' : 'npm'
-const res = spawnSync(npmCmd, ['run', script], {
+const isWindows = os.platform() === 'win32'
+const opts = {
   cwd: root,
-  stdio: 'inherit',
-  shell: os.platform() === 'win32'
-})
+  stdio: 'inherit'
+}
+const res = isWindows
+  ? spawnSync(`npm.cmd run ${script}`, { ...opts, shell: true })
+  : spawnSync('npm', ['run', script], opts)
 if (res.error) {
   console.error(res.error.message)
   process.exit(1)

--- a/scripts/link-win32-dev.js
+++ b/scripts/link-win32-dev.js
@@ -3,9 +3,10 @@
 
 const fs = require('fs')
 const path = require('path')
+const os = require('os')
 
 const root = path.resolve(__dirname, '..')
-const arch = process.argv[2]
+const arch = os.arch()
 const runtimeRel = path.join('by-arch', `win32-${arch}`, 'bin', 'pear.exe')
 const runtime = path.join(root, runtimeRel)
 const ps1 = path.join(root, 'pear.ps1')

--- a/scripts/link-win32-dev.js
+++ b/scripts/link-win32-dev.js
@@ -5,7 +5,8 @@ const fs = require('fs')
 const path = require('path')
 
 const root = path.resolve(__dirname, '..')
-const runtimeRel = path.join('by-arch', 'win32-x64', 'bin', 'pear.exe')
+const arch = process.argv[2]
+const runtimeRel = path.join('by-arch', `win32-${arch}`, 'bin', 'pear.exe')
 const runtime = path.join(root, runtimeRel)
 const ps1 = path.join(root, 'pear.ps1')
 


### PR DESCRIPTION
`npm run make`
`npm run make:win32-arm64`

---

* Sub-task: solved this warning:

```bash
$ npm run make

(node:5052) [DEP0190] DeprecationWarning: Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

---

<img width="1232" height="683" alt="image" src="https://github.com/user-attachments/assets/70c7aec1-a081-44ab-b265-854f8dfc3096" />
