### PR TITLE
pear seed fixes

### DIFF
--- a/cmd/seed.js
+++ b/cmd/seed.js
@@ -51,7 +51,7 @@ module.exports = async function seed(cmd) {
       key: 'contentKey',
       label: appendMode ? `${ansi.gray('...')} content key` : 'Content Key:',
       initial: loading,
-      transform: (v) => ansi.gray(v)
+      transform: (v) => (v === undefined ? ansi.yellow('loading...') : ansi.gray(v))
     },
     {
       key: 'firewalled',

--- a/cmd/seed.js
+++ b/cmd/seed.js
@@ -51,7 +51,7 @@ module.exports = async function seed(cmd) {
       key: 'contentKey',
       label: appendMode ? `${ansi.gray('...')} content key` : 'Content Key:',
       initial: loading,
-      transform: (v) => (v === undefined ? ansi.yellow('unknown...') : ansi.gray(v))
+      transform: (v) => (v === 'pending' ? ansi.yellow(v) : ansi.gray(v))
     },
     {
       key: 'firewalled',
@@ -151,7 +151,9 @@ module.exports = async function seed(cmd) {
       stats.update({
         driveKey: hypercoreid.normalize(driveKey),
         discoveryKey: hypercoreid.normalize(discoveryKey),
-        contentKey: contentKey && hypercoreid.normalize(contentKey),
+        contentKey: hypercoreid.isValid(contentKey)
+          ? hypercoreid.normalize(contentKey)
+          : contentKey,
         firewalled,
         natType,
         network

--- a/cmd/seed.js
+++ b/cmd/seed.js
@@ -51,7 +51,7 @@ module.exports = async function seed(cmd) {
       key: 'contentKey',
       label: appendMode ? `${ansi.gray('...')} content key` : 'Content Key:',
       initial: loading,
-      transform: (v) => (v === undefined ? ansi.yellow('loading...') : ansi.gray(v))
+      transform: (v) => (v === undefined ? ansi.yellow('unknown...') : ansi.gray(v))
     },
     {
       key: 'firewalled',

--- a/subsystems/sidecar/ops/seed.js
+++ b/subsystems/sidecar/ops/seed.js
@@ -101,7 +101,7 @@ module.exports = class Seed extends Opstream {
 
     await replicator.join(this.sidecar.swarm, { server: true, client: true })
 
-    await drive.get('/package.json')
+    drive.db.core.download({ start: 0, end: -1 })
 
     this._statsInterval = setInterval(() => {
       this.push(this._stats({ drive }))

--- a/subsystems/sidecar/ops/seed.js
+++ b/subsystems/sidecar/ops/seed.js
@@ -24,7 +24,7 @@ module.exports = class Seed extends Opstream {
         peers: drive.core.peers.length,
         driveKey: drive.key?.toString('hex'),
         discoveryKey: drive.discoveryKey?.toString('hex'),
-        contentKey: drive.contentKey?.toString('hex'),
+        contentKey: drive.contentKey?.toString('hex') ?? 'pending',
         upload: {
           totalBytes: this.stats.totals.upload.bytes,
           totalBlocks: this.stats.totals.upload.blocks,

--- a/test/03-seed.test.js
+++ b/test/03-seed.test.js
@@ -4,6 +4,7 @@ const Corestore = require('corestore')
 const Hyperdrive = require('hyperdrive')
 const Hyperswarm = require('hyperswarm')
 const hypercoreid = require('hypercore-id-encoding')
+const Localdrive = require('localdrive')
 const Helper = require('./helper')
 
 test('pear seed basic stage and seed', async function ({ ok, plan, comment, teardown, timeout }) {
@@ -108,4 +109,52 @@ test('pear seed announces, join, drop', async function ({
 
   const dropped = await until['peer-remove']
   ok(dropped, 'peer drops')
+})
+
+test('pear seed fully syncs db and blobs cores', async function ({
+  is,
+  plan,
+  comment,
+  teardown,
+  timeout,
+  tmp
+}) {
+  timeout(180000)
+  plan(2)
+
+  const sourceStore = new Corestore(await tmp())
+  teardown(() => sourceStore.close())
+  await sourceStore.ready()
+  const sourceDrive = new Hyperdrive(sourceStore)
+  await sourceDrive.ready()
+  await new Localdrive(Helper.fixture('minimal')).mirror(sourceDrive).done()
+  const sourceBlobs = await sourceDrive.getBlobs()
+  const blocks = sourceDrive.db.core.length + sourceBlobs.core.length
+
+  let dbBlocks = 0
+  sourceDrive.db.core.on('upload', () => dbBlocks++)
+
+  let blobBlocks = 0
+  sourceBlobs.core.on('upload', () => blobBlocks++)
+
+  const sourceSwarm = new Hyperswarm({ bootstrap: Helper.dhtBootstrap })
+  teardown(() => sourceSwarm.destroy())
+  sourceSwarm.on('connection', (conn) => {
+    sourceStore.replicate(conn)
+  })
+  const topic = sourceSwarm.join(sourceDrive.discoveryKey, { server: true, client: false })
+  await topic.flushed()
+
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+
+  comment('seeding external app')
+  const link = `pear://${hypercoreid.encode(sourceDrive.key)}`
+  const seeding = helper.seed({ link })
+  teardown(() => Helper.teardownStream(seeding))
+  await Helper.pick(seeding, { tag: 'stats', data: { download: { totalBlocks: blocks } } })
+
+  is(dbBlocks, sourceDrive.db.core.length, 'seed synced db core')
+  is(blobBlocks, sourceBlobs.core.length, 'seed synced blobs core')
 })

--- a/test/03-seed.test.js
+++ b/test/03-seed.test.js
@@ -110,6 +110,21 @@ test('pear seed announces, join, drop', async function ({
   ok(dropped, 'peer drops')
 })
 
+test('pear seed empty drive has pending content key', async function ({ is, plan, teardown }) {
+  plan(1)
+
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+  const link = await Helper.touchLink(helper)
+
+  const seeding = helper.seed({ link })
+  teardown(() => Helper.teardownStream(seeding))
+  const stats = await Helper.pick(seeding, { tag: 'stats', data: { contentKey: 'pending' } })
+
+  is(stats.contentKey, 'pending', 'content key is pending')
+})
+
 test('pear seed fully syncs db and blobs cores', async function ({
   is,
   plan,

--- a/test/03-seed.test.js
+++ b/test/03-seed.test.js
@@ -4,7 +4,6 @@ const Corestore = require('corestore')
 const Hyperdrive = require('hyperdrive')
 const Hyperswarm = require('hyperswarm')
 const hypercoreid = require('hypercore-id-encoding')
-const Localdrive = require('localdrive')
 const Helper = require('./helper')
 
 test('pear seed basic stage and seed', async function ({ ok, plan, comment, teardown, timeout }) {
@@ -127,9 +126,9 @@ test('pear seed fully syncs db and blobs cores', async function ({
   await sourceStore.ready()
   const sourceDrive = new Hyperdrive(sourceStore)
   await sourceDrive.ready()
-  await new Localdrive(Helper.fixture('minimal')).mirror(sourceDrive).done()
+  await sourceDrive.put('/index.js', 'module.exports = {}\n')
+  await sourceDrive.put('/test.txt', 'test')
   const sourceBlobs = await sourceDrive.getBlobs()
-  const blocks = sourceDrive.db.core.length + sourceBlobs.core.length
 
   let dbBlocks = 0
   sourceDrive.db.core.on('upload', () => dbBlocks++)
@@ -149,12 +148,13 @@ test('pear seed fully syncs db and blobs cores', async function ({
   teardown(() => helper.close(), { order: Infinity })
   await helper.ready()
 
-  comment('seeding external app')
+  comment('seeding source drive')
   const link = `pear://${hypercoreid.encode(sourceDrive.key)}`
   const seeding = helper.seed({ link })
   teardown(() => Helper.teardownStream(seeding))
-  await Helper.pick(seeding, { tag: 'stats', data: { download: { totalBlocks: blocks } } })
+  const totalBlocks = sourceDrive.db.core.length + sourceBlobs.core.length
+  await Helper.pick(seeding, { tag: 'stats', data: { download: { totalBlocks } } })
 
-  is(dbBlocks, sourceDrive.db.core.length, 'seed synced db core')
-  is(blobBlocks, sourceBlobs.core.length, 'seed synced blobs core')
+  is(dbBlocks, sourceDrive.db.core.length, 'synced db core')
+  is(blobBlocks, sourceBlobs.core.length, 'synced blobs core')
 })


### PR DESCRIPTION
* fix: sync full `db.core`
* new test that fails on main branch but passes green in this PR branch, confirming db and blobs are fully downloaded

---

## subtasks

* new test: 'pending' status of Content Key

* no need to fetch '/package.json', was used before to verify an encrypted app (v2 legacy)

* Highlight in yellow 'pending' when seeding an empty key (`pear touch`) to indicate "something needs attention", value will change in real-time when source peer finally stage-seed something.

---

<img width="758" height="226" alt="image" src="https://github.com/user-attachments/assets/b369a9ce-c999-48c2-a43c-41ea70897d74" />

