### PR TITLE
sidecar log fixes

### DIFF
--- a/cmd/sidecar.js
+++ b/cmd/sidecar.js
@@ -32,8 +32,8 @@ module.exports = async function sidecar(cmd) {
   print('Sidecar has shutdown', true)
   if (cmd.command.name === 'shutdown') return
 
-  print('Rebooting current process as Sidecar\n  - [ ' + key + ' ]', 0)
-  print(ansi.gray('Runtime: ' + path.basename(constants.RUNTIME)), 0)
+  print('Rebooting current process as Sidecar', 0)
+  print('Runtime: ' + path.basename(constants.RUNTIME), 0)
   print('\n========================= INIT ===================================\n')
 
   Logger.switches.labels += (Logger.switches.labels.length > 0 ? ',' : '') + 'sidecar'
@@ -47,7 +47,7 @@ module.exports = async function sidecar(cmd) {
 
   print('\n~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n')
   print('Current process is now Sidecar', true)
-  print(ansi.gray('Version: ' + JSON.stringify({ key, version }, 0, 4).slice(0, -1) + '  }'), 0)
+  print(ansi.gray(JSON.stringify({ version, key }, 0, 4)))
   if (restarts.length > 0) {
     print('Restart Commands:', 0)
     for (const { cmdArgs = [] } of restarts) {

--- a/subsystems/sidecar/index.js
+++ b/subsystems/sidecar/index.js
@@ -338,7 +338,7 @@ class Sidecar extends ReadyResource {
       if (this.updater) {
         try {
           await this.updater.applyUpdate()
-          LOG.info('sidecar', LOG.CHECKMARK + ' Applied update')
+          LOG.info('sidecar', CHECKMARK + ' Applied update')
         } catch (err) {
           LOG.error('sidecar', err)
         }


### PR DESCRIPTION
* `[object Object]` 'key: production/stage/dev', but instead of fixing I suggest removing this line because the same values already get printed after
* fix: undefined LOG.CHECKMARK
* simpler json stringify output
* `Runtime: pear-runtime` same style as other lines

---

before / after

<img width="1470" height="575" alt="image" src="https://github.com/user-attachments/assets/db8b9d47-43bf-4c3e-9b46-a74d6c0be21a" />
