### PR TITLE
Persist share debug logs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,7 +8,7 @@ const { spawn: daemon } = require('bare-daemon')
 const { SOCKET_PATH, CONNECT_TIMEOUT, PLATFORM_DIR, LOCALDEV } = require('./constants.js')
 const context = require('./context')
 const cmd = require('./cmd')
-const { normalizedArgv } = require('./argv')
+const { cmdArgs, normalizedArgv } = require('./argv')
 crasher('cli')
 
 cli()
@@ -24,20 +24,52 @@ async function cli() {
 }
 
 function tryboot() {
-  const argv = normalizedArgv
-  const args = ['--sidecar']
-  const bootstrapArgIndex = argv.indexOf('--dht-bootstrap')
-  if (bootstrapArgIndex !== -1 && argv[bootstrapArgIndex + 1]) {
-    args.push('--dht-bootstrap', argv[bootstrapArgIndex + 1])
-  }
+  const args = ['--sidecar', ...forwardSidecarArgs(cmdArgs)]
   const runtime = os.execPath()
   if (!runtime) {
     throw new Error(
       `Unable to resolve pear runtime executable for sidecar spawn (cwd=${safeCwd() || 'n/a'})`
     )
   }
-  if (LOCALDEV) args.unshift(argv[0])
+  if (LOCALDEV) args.unshift(normalizedArgv[0])
   daemon(runtime, args, { cwd: resolveSpawnCwd(runtime) })
+}
+
+function forwardSidecarArgs(argv) {
+  const valueFlags = new Set([
+    '--dht-bootstrap',
+    '--log-fields',
+    '-F',
+    '--log-file',
+    '--log-labels',
+    '-l',
+    '--log-level',
+    '-L'
+  ])
+  const boolFlags = new Set([
+    '--log',
+    '--log-max',
+    '-M',
+    '--log-stacks',
+    '-S',
+    '--log-verbose',
+    '-V'
+  ])
+  const forwarded = []
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]
+    if (arg === '--') break
+    if (boolFlags.has(arg)) forwarded.push(arg)
+    else if (valueFlags.has(arg) && argv[i + 1]) forwarded.push(arg, argv[++i])
+    else if (arg.startsWith('--dht-bootstrap=')) forwarded.push(arg)
+    else if (arg.startsWith('--log-fields=')) forwarded.push(arg)
+    else if (arg.startsWith('--log-file=')) forwarded.push(arg)
+    else if (arg.startsWith('--log-labels=')) forwarded.push(arg)
+    else if (arg.startsWith('--log-level=')) forwarded.push(arg)
+  }
+
+  return forwarded
 }
 
 function safeCwd() {

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -21,6 +21,7 @@ const commands = {
   changelog: require('./changelog'),
   sidecar: require('./sidecar'),
   gc: require('./gc'),
+  logs: require('./logs'),
   versions: require('./versions')
 }
 
@@ -333,6 +334,7 @@ module.exports = async (ipc, argv = cmdArgs) => {
     flag('--log-level <level>', 'Level to log at. 0,1,2,3 (OFF,ERR,INF,TRC)'),
     flag('--log-labels <list>', 'Labels to log (internal, always logged)'),
     flag('--log-fields <list>', 'Show/hide: date,time,h:level,h:label,h:delta'),
+    flag('--log-file <path>', 'Append sidecar logs and crashes to a file'),
     flag('--log-stacks', 'Add a stack trace to each log message'),
     flag('--dht-bootstrap <nodes>').hide(),
     commands.sidecar
@@ -352,6 +354,29 @@ module.exports = async (ipc, argv = cmdArgs) => {
     () => {
       console.log(gc.help())
     }
+  )
+
+  const logs = command(
+    'logs',
+    summary('Show platform log files'),
+    description`
+      Print or collect platform logs for debugging.
+    `,
+    command(
+      'bundle',
+      summary('Copy logs into a shareable directory'),
+      arg('[dir]'),
+      flag('--json', 'Newline delimited JSON output'),
+      commands.logs
+    ),
+    command(
+      'clear',
+      summary('Remove platform log files'),
+      flag('--json', 'Newline delimited JSON output'),
+      commands.logs
+    ),
+    flag('--json', 'Newline delimited JSON output'),
+    commands.logs
   )
 
   const versions = command(
@@ -384,6 +409,7 @@ module.exports = async (ipc, argv = cmdArgs) => {
     changelog,
     sidecar,
     gc,
+    logs,
     versions,
     help,
     footer(usage.footer),

--- a/cmd/logs.js
+++ b/cmd/logs.js
@@ -1,0 +1,64 @@
+'use strict'
+const diagnostics = require('../lib/diagnostics.js')
+const Logger = require('../lib/logger.js')
+const { ansi, byteSize, print } = require('../lib/terminal.js')
+
+module.exports = async function logs(cmd) {
+  const json = hasFlag(cmd, 'json')
+  const action = cmd.command.name
+
+  if (action === 'clear') {
+    await diagnostics.clear()
+    if (json) console.log(JSON.stringify({ logs: { cleared: true } }))
+    else print('Logs cleared', true)
+    return
+  }
+
+  if (action === 'bundle') {
+    const result = await diagnostics.bundle(cmd.args.dir)
+    if (json) console.log(JSON.stringify({ logs: result }))
+    else print(formatBundle(result), true)
+    return
+  }
+
+  const info = diagnostics.snapshot(Logger.switches.logFile)
+  if (json) console.log(JSON.stringify({ logs: info }))
+  else print(formatInfo(info))
+}
+
+function formatInfo(info) {
+  const files = info.files.length
+    ? info.files.map((file) => `  ${file.path} ${ansi.dim(byteSize(file.bytes))}`).join('\n')
+    : `  ${ansi.dim('[ No log files ]')}`
+
+  return [
+    '',
+    `${ansi.bold('Platform')} ${info.platformDir}`,
+    `${ansi.bold('Logs')} ${info.logsDir}`,
+    '',
+    `${ansi.bold('Write runtime logs')}`,
+    `  pear --log --log-file ${info.logFile} <cmd>`,
+    '',
+    `${ansi.bold('Crash logs')}`,
+    `  CLI      ${info.crashLogs.cli}`,
+    `  Sidecar  ${info.crashLogs.sidecar}`,
+    '',
+    `${ansi.bold('Files')}`,
+    files,
+    ''
+  ].join('\n')
+}
+
+function formatBundle(result) {
+  const files = result.files.length
+    ? `${result.files.length} file${result.files.length === 1 ? '' : 's'} copied`
+    : 'No log files found'
+  return `${files}\n${result.path}`
+}
+
+function hasFlag(cmd, name) {
+  for (let c = cmd.command; c; c = c.parent) {
+    if (c.flags?.[name]) return true
+  }
+  return false
+}

--- a/cmd/sidecar.js
+++ b/cmd/sidecar.js
@@ -5,6 +5,7 @@ const gracedown = require('pear-gracedown')
 const { isWindows } = require('which-runtime')
 const { print, ansi, stdio, isTTY } = require('../lib/terminal.js')
 const Logger = require('../lib/logger.js')
+const diagnostics = require('../lib/diagnostics.js')
 const constants = require('../constants.js')
 const { upgrade: key, version } = require('../package.json')
 module.exports = async function sidecar(cmd) {
@@ -37,8 +38,16 @@ module.exports = async function sidecar(cmd) {
   print('\n========================= INIT ===================================\n')
 
   Logger.switches.labels += (Logger.switches.labels.length > 0 ? ',' : '') + 'sidecar'
+  let refreshLog = false
+  if (cmd.flags.logFile) {
+    Logger.switches.logFile = diagnostics.resolveLogFile(cmd.flags.logFile)
+    refreshLog = true
+  }
   if (Logger.switches.level < 2) {
     Logger.switches.level = 2
+    refreshLog = true
+  }
+  if (refreshLog) {
     global.LOG = new Logger({ pretty: true })
   }
 

--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -10,6 +10,7 @@ const definition = [
   flag('--log-stacks|-S', 'Add a stack trace to each log message'),
   flag('--log-max|-M', 'Log with all levels, logs and fields'),
   flag('--log', 'Default logs: -l sidecar -L 2 -F h:level,h:label'),
+  flag('--log-file <path>', 'Append logs and crashes to a file. Implies --log'),
   flag('--sidecar', 'Raw boot Sidecar'),
   flag('--dht-bootstrap <nodes>').hide()
 ]

--- a/lib/crasher.js
+++ b/lib/crasher.js
@@ -1,15 +1,15 @@
 'use strict'
 const { platform, arch } = require('which-runtime')
-const fs = require('bare-fs')
-const path = require('bare-path')
 const pid = global.Bare.pid
-const { PLATFORM_DIR, UPGRADE, VERSION } = require('../constants.js')
+const { UPGRADE, VERSION } = require('../constants.js')
+const diagnostics = require('./diagnostics.js')
+const Logger = require('./logger.js')
 
 let hasLoggedUnhandledRejection = false
 let hasLoggedUncaughtException = false
 
 const start = Date.now()
-function logCrash(logPath, errorInfo, stackTrace, err) {
+function logCrash(logPaths, errorInfo, stackTrace, err) {
   const timeStamp = new Date().toISOString()
   const uptime = (Date.now() - start) / 1000
   const processInfo = `platform=${platform}\narch=${arch}\npid=${pid}\nuptime=${uptime}s`
@@ -18,9 +18,12 @@ function logCrash(logPath, errorInfo, stackTrace, err) {
   const errorMsg = `${timeStamp} ${errorInfo}\n${UPGRADE} - ${VERSION}\n${processInfo}\nstack=${stackTrace + errInfo}\n\n`
 
   console.error(errorMsg)
-  fs.writeFileSync(logPath, errorMsg, { flag: 'a', encoding: 'utf8' })
 
-  console.error(`Error logged at ${logPath}`)
+  for (const logPath of logPaths) {
+    diagnostics.append(logPath, errorMsg)
+  }
+
+  console.error(`Error logged at ${logPaths.join(', ')}`)
 }
 
 function printCrash(errorInfo, stackTrace, err) {
@@ -31,9 +34,9 @@ function printCrash(errorInfo, stackTrace, err) {
   console.error(errorMsg)
 }
 
-function logAndExit(enableLog, logPath, errorInfo, stack, err) {
-  if (enableLog) {
-    logCrash(logPath, errorInfo, stack, err)
+function logAndExit(logPaths, errorInfo, stack, err) {
+  if (logPaths.length) {
+    logCrash(logPaths, errorInfo, stack, err)
   } else {
     printCrash(errorInfo, stack, err)
   }
@@ -41,8 +44,13 @@ function logAndExit(enableLog, logPath, errorInfo, stack, err) {
   global.Bare.exit(1)
 }
 
-function setupCrashHandlers(processName, enableLog) {
-  const crashlogPath = path.join(PLATFORM_DIR, `${processName}.crash.log`)
+function setupCrashHandlers(processName, enableLog = true) {
+  const crashlogPath = diagnostics.crashLogPath(processName)
+  const logPaths = enableLog ? [crashlogPath] : []
+  if (Logger.switches.logFile && logPaths.includes(Logger.switches.logFile) === false) {
+    logPaths.unshift(Logger.switches.logFile)
+  }
+  if (logPaths.length) diagnostics.ensureDir()
   const runContext = global.Bare
 
   runContext.on('unhandledRejection', (reason) => {
@@ -51,7 +59,7 @@ function setupCrashHandlers(processName, enableLog) {
 
     const stack = reason?.stack || reason || ''
     const errorInfo = `${processName} exiting due to unhandled rejection`
-    logAndExit(enableLog, crashlogPath, errorInfo, stack, reason)
+    logAndExit(logPaths, errorInfo, stack, reason)
   })
 
   runContext.on('uncaughtException', (err) => {
@@ -59,7 +67,7 @@ function setupCrashHandlers(processName, enableLog) {
     hasLoggedUncaughtException = true
 
     const errorInfo = `${processName} exiting due to uncaught exception`
-    logAndExit(enableLog, crashlogPath, errorInfo, err.stack, err)
+    logAndExit(logPaths, errorInfo, err.stack, err)
   })
 }
 

--- a/lib/diagnostics.js
+++ b/lib/diagnostics.js
@@ -1,0 +1,94 @@
+'use strict'
+const fs = require('bare-fs')
+const path = require('bare-path')
+const { arch, platform } = require('which-runtime')
+const { PLATFORM_DIR, UPGRADE, VERSION } = require('../constants.js')
+
+const LOGS_DIR = path.join(PLATFORM_DIR, 'logs')
+const DEFAULT_LOG_FILE = path.join(LOGS_DIR, 'pear.log')
+
+function ensureDir(dir = LOGS_DIR) {
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+function resolveLogFile(file) {
+  if (!file) return ''
+  return path.resolve(file)
+}
+
+function crashLogPath(name) {
+  return path.join(LOGS_DIR, `${name}.crash.log`)
+}
+
+function append(file, msg) {
+  ensureDir(path.dirname(file))
+  fs.writeFileSync(file, msg, { flag: 'a', encoding: 'utf8' })
+}
+
+function list() {
+  try {
+    return fs
+      .readdirSync(LOGS_DIR)
+      .map((name) => {
+        const file = path.join(LOGS_DIR, name)
+        const stat = fs.statSync(file)
+        return stat.isFile() ? { name, path: file, bytes: stat.size } : null
+      })
+      .filter(Boolean)
+      .sort((a, b) => a.name.localeCompare(b.name))
+  } catch {
+    return []
+  }
+}
+
+async function bundle(dir) {
+  const target = path.resolve(dir || `pear-logs-${new Date().toISOString().replace(/[:.]/g, '-')}`)
+  const files = list()
+
+  await fs.promises.mkdir(target, { recursive: true })
+
+  for (const file of files) {
+    await fs.promises.copyFile(file.path, path.join(target, file.name))
+  }
+
+  return { path: target, files }
+}
+
+async function clear() {
+  await fs.promises.rm(LOGS_DIR, { recursive: true }).catch(() => {})
+}
+
+function snapshot(logFile = '') {
+  return {
+    platformDir: PLATFORM_DIR,
+    logsDir: LOGS_DIR,
+    logFile: logFile || DEFAULT_LOG_FILE,
+    crashLogs: {
+      cli: crashLogPath('cli'),
+      sidecar: crashLogPath('sidecar')
+    },
+    runtime: {
+      version: VERSION,
+      upgrade: UPGRADE,
+      bare: Bare.versions.bare,
+      platform,
+      arch,
+      pid: Bare.pid
+    },
+    files: list()
+  }
+}
+
+module.exports = {
+  LOGS_DIR,
+  DEFAULT_LOG_FILE,
+  append,
+  bundle,
+  clear,
+  crashLogPath,
+  ensureDir,
+  list,
+  resolveLogFile,
+  snapshot
+}

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -2,16 +2,19 @@
 const { formatWithOptions } = require('bare-format')
 const hrtime = require('bare-hrtime')
 const { cmdArgs } = require('../argv')
+const diagnostics = require('./diagnostics')
 const pear = require('./cmd').command(cmdArgs)
 const max = pear?.flags.logMax ?? false
 const verbose = pear?.flags.logVerbose || max
-const log = pear?.flags.log || !!pear?.flags.logLabels || verbose || max
+const logFile = diagnostics.resolveLogFile(pear?.flags.logFile)
+const log = pear?.flags.log || !!pear?.flags.logLabels || !!logFile || verbose || max
 const switches = {
   log,
   level: pear?.flags.logLevel ?? (max ? 3 : log ? 2 : 1),
   labels: pear?.flags.logLabels ?? '',
   fields: verbose ? 'date,time,level,label,delta' : (pear?.flags.logFields ?? ''),
   stacks: pear?.flags.logStacks ?? false,
+  logFile,
   verbose,
   max
 }
@@ -45,6 +48,7 @@ class Logger {
       }
     }
     this.stack = ''
+    this._logFile = this.constructor.switches.logFile
     this.LEVEL = this._parseLevel(level ?? this.constructor.switches.level)
     this._tty = null
   }
@@ -90,10 +94,10 @@ class Logger {
     if (this._stacks) Error.captureStackTrace(this, this.error)
     args = this._args('ERR', label, ...args)
     if (this._stacks) {
-      console.error(...args, this.stack)
+      this._write('error', args, this.stack)
       this.stack = ''
     } else {
-      console.error(...args)
+      this._write('error', args)
     }
   }
 
@@ -107,10 +111,10 @@ class Logger {
     if (this._stacks) Error.captureStackTrace(this, this.info)
     args = this._args('INF', label, ...args)
     if (this._stacks) {
-      console.log(...args, this.stack)
+      this._write('log', args, this.stack)
       this.stack = ''
     } else {
-      console.log(...args)
+      this._write('log', args)
     }
   }
 
@@ -124,10 +128,10 @@ class Logger {
     if (this._stacks) Error.captureStackTrace(this, this.trace)
     args = this._args('TRC', label, ...args)
     if (this._stacks) {
-      console.error(...args, this.stack)
+      this._write('error', args, this.stack)
       this.stack = ''
     } else {
-      console.error(...args)
+      this._write('error', args)
     }
   }
 
@@ -214,6 +218,16 @@ class Logger {
   _parseLabels(labels) {
     if (typeof labels !== 'string') return labels
     return labels.split(',')
+  }
+
+  _write(method, args, stack = '') {
+    if (this._logFile) {
+      const lineArgs = stack ? args.concat(stack) : args
+      const line = formatWithOptions({ colors: false }, ...lineArgs).replace(/\u0000/g, '')
+      diagnostics.append(this._logFile, line + '\n')
+    }
+    if (stack) console[method](...args, stack)
+    else console[method](...args)
   }
 }
 


### PR DESCRIPTION
Added --log-file <path> to persist runtime logs.
Persisted CLI and sidecar crash logs by default.
Added pear logs to inspect diagnostic log locations and files.
Added pear logs bundle [dir] to create a shareable log bundle.
Added pear logs clear to remove persisted logs.
Forwarded logging/debug options when spawning the sidecar.
Added JSON output support for log commands.