### PR TITLE
fix: localdev Windows Bare detection

### DIFF
--- a/main.js
+++ b/main.js
@@ -6,7 +6,7 @@ const { init } = require('./constants.js')
 
 const executable = resolveExecutable()
 const devRoot = resolveDevRoot(executable)
-const standalone = path.basename(Bare.argv[0]) !== 'bare'
+const standalone = path.basename(Bare.argv[0]) !== (isWindows ? 'bare.exe' : 'bare')
 
 module.exports = (channel) => {
   init(channel, standalone, devRoot)


### PR DESCRIPTION
Note: this bug is only in localdev, not standalone builds (`.\out\make\pear.exe`)

main branch
<img width="1116" height="632" alt="Screenshot 2026-07-24 at 13 59 48" src="https://github.com/user-attachments/assets/a9806d5f-575b-4911-b779-f3801474046c" />

PR branch
<img width="1118" height="633" alt="Screenshot 2026-07-24 at 13 59 08" src="https://github.com/user-attachments/assets/e5db4d46-d3b5-47c5-83ed-9ccb08a3a139" />
