### PR TITLE
Improve onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Pear Runtime Changelog
 
+## v3.1.0
+
+### Improvements
+
+* CLI - next-step onboarding hints for the release flow (`stage`, `provision`, `multisig keys get`/`link`/`request`/`sign`/`verify`/`commit`) - printed to stderr, suppressed by `--json`, so stdout and `--json` output are unchanged
+* CLI - `pear multisig verify` no longer suggests seeding after a dry run; it now points to the next verify/commit step
+
 ## v3.0.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Pear Runtime Changelog
 
-## v3.1.0
-
-### Improvements
-
-* CLI - `pear multisig verify` no longer suggests seeding after a dry run; it now points to the next verify/commit step
-
 ## v3.0.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Improvements
 
-* CLI - next-step onboarding hints for the release flow (`stage`, `provision`, `multisig keys get`/`link`/`request`/`sign`/`verify`/`commit`) - printed to stderr, suppressed by `--json`, so stdout and `--json` output are unchanged
 * CLI - `pear multisig verify` no longer suggests seeding after a dry run; it now points to the next verify/commit step
 
 ## v3.0.1

--- a/cmd/multisig.js
+++ b/cmd/multisig.js
@@ -290,8 +290,8 @@ class Multisig {
 
     if (!this.json) {
       hint(
-        'Set this as the upgrade link in package.json. When you have a versioned, seeded source link, request signatures:',
-        ['pear multisig request <verlink>']
+        'Before requesting signatures, set this as package.json upgrade and produce a seeded provisioned build against the multisig link:',
+        ['pear multisig request <versioned-provision-link>']
       )
     }
   }
@@ -341,7 +341,7 @@ class Multisig {
 
     if (!this.json && final?.request) {
       hint('Send this request to each signer. Each signs it with their key:', [
-        'pear multisig sign ' + final.request
+        'pear multisig sign <request>'
       ])
     }
   }
@@ -372,11 +372,11 @@ class Multisig {
     if (!this.json) {
       if (responses.length === 0) {
         hint('Request verified. Once signers return their responses, verify again with them:', [
-          'pear multisig verify ' + sourceLink + ' ' + request + ' <response> [<response> ...]'
+          'pear multisig verify <source-link> <request> <response> [<response> ...]'
         ])
       } else {
         hint('If verification passed, commit to go live:', [
-          'pear multisig commit ' + sourceLink + ' ' + request + ' ' + responses.join(' ')
+          'pear multisig commit <source-link> <request> <response> [<response> ...]'
         ])
       }
     }
@@ -407,9 +407,8 @@ class Multisig {
     )
 
     if (!this.json && final?.dstKey) {
-      const link = plink.serialize({ drive: { key: final.dstKey } })
       hint('The commit is not safe until peers seed it. Seed the multisig link:', [
-        'pear seed ' + link
+        'pear seed <multisig-link>'
       ])
     }
   }

--- a/cmd/multisig.js
+++ b/cmd/multisig.js
@@ -343,6 +343,9 @@ class Multisig {
       hint('Send this request to each signer. Each signs it with their key:', [
         'pear multisig sign <request>'
       ])
+      hint('Once signers return their responses, verify them:', [
+        'pear multisig verify <source-link> <request> <response> [<response> ...]'
+      ])
     }
   }
 
@@ -408,7 +411,7 @@ class Multisig {
 
     if (!this.json && final?.dstKey) {
       hint('The commit is not safe until peers seed it. Seed the multisig link:', [
-        'pear seed <multisig-link>'
+        'pear seed <link>'
       ])
     }
   }

--- a/cmd/multisig.js
+++ b/cmd/multisig.js
@@ -2,7 +2,7 @@
 const context = require('../context')
 const path = require('bare-path')
 const os = require('bare-os')
-const { outputter, password } = require('../lib/terminal.js')
+const { outputter, password, hint } = require('../lib/terminal.js')
 const hypercoreid = require('hypercore-id-encoding')
 const z32 = require('z32')
 const fs = require('bare-fs')
@@ -73,6 +73,7 @@ class Keys {
         data.privateKey = fs.existsSync(this.prv) ? fs.readFileSync(this.prv) : '(no secret key)'
       }
       await Keys.output(this.json, [{ tag: 'key', data }, { tag: 'final' }])
+      if (!this.json) this.#nextHint()
       return
     }
     const input = await password()
@@ -94,6 +95,13 @@ class Keys {
     }
     if (secret) data.privateKey = secretKey
     await Keys.output(this.json, [{ tag: 'key', data }, { tag: 'final' }])
+    if (!this.json) this.#nextHint()
+  }
+
+  #nextHint() {
+    hint('Add this public key to multisig.publicKeys in pear.json, then get the multisig link:', [
+      'pear multisig link'
+    ])
   }
 
   async paths() {
@@ -211,10 +219,7 @@ class Multisig {
         link +
         '\n' +
         'verlink: ' +
-        verlink +
-        '\n' +
-        'seed: pear seed ' +
-        link
+        verlink
       )
     }
   })
@@ -282,6 +287,13 @@ class Multisig {
     }
 
     await Multisig.output(this.json, this.ipc.multisig({ action: 'link', ...config }))
+
+    if (!this.json) {
+      hint(
+        'Set this as the upgrade link in package.json. When you have a versioned, seeded source link, request signatures:',
+        ['pear multisig request <verlink>']
+      )
+    }
   }
 
   async sign() {
@@ -307,12 +319,16 @@ class Multisig {
     const at = { pub: pub.replace(HOME, '~'), prv: prv.replace(HOME, '~') }
     const response = z32.encode(hs.sign(req, key, pwd))
     await Multisig.output(this.json, [{ tag: 'sign', data: { response, at } }, { tag: 'final' }])
+
+    if (!this.json) {
+      hint('Send this response back to the release coordinator, who verifies and commits it.')
+    }
   }
 
   async request() {
     const { force, peerUpdateTimeout } = this.cmd.flags
     const { verlink } = this.cmd.args
-    await Multisig.output(
+    const final = await Multisig.output(
       this.json,
       this.ipc.multisig({
         action: 'request',
@@ -322,6 +338,12 @@ class Multisig {
         peerUpdateTimeout
       })
     )
+
+    if (!this.json && final?.request) {
+      hint('Send this request to each signer. Each signs it with their key:', [
+        'pear multisig sign ' + final.request
+      ])
+    }
   }
 
   async verify() {
@@ -346,6 +368,18 @@ class Multisig {
         peerUpdateTimeout
       })
     )
+
+    if (!this.json) {
+      if (responses.length === 0) {
+        hint('Request verified. Once signers return their responses, verify again with them:', [
+          'pear multisig verify ' + sourceLink + ' ' + request + ' <response> [<response> ...]'
+        ])
+      } else {
+        hint('If verification passed, commit to go live:', [
+          'pear multisig commit ' + sourceLink + ' ' + request + ' ' + responses.join(' ')
+        ])
+      }
+    }
   }
 
   async commit() {
@@ -358,7 +392,7 @@ class Multisig {
       const res = z32.decode(response)
       if (!hs.isResponse(res)) throw ERR_INVALID_INPUT('Invalid response: ' + response)
     }
-    await Multisig.output(
+    const final = await Multisig.output(
       this.json,
       this.ipc.multisig({
         action: 'commit',
@@ -371,6 +405,13 @@ class Multisig {
         peerUpdateTimeout
       })
     )
+
+    if (!this.json && final?.dstKey) {
+      const link = plink.serialize({ drive: { key: final.dstKey } })
+      hint('The commit is not safe until peers seed it. Seed the multisig link:', [
+        'pear seed ' + link
+      ])
+    }
   }
 }
 

--- a/cmd/provision.js
+++ b/cmd/provision.js
@@ -101,12 +101,8 @@ module.exports = async function provision(cmd) {
         'pear provision ' + sourceVerlink + ' ' + targetLink + ' ' + productionVerlink
       ])
     } else if (final?.target) {
-      hint('Seed the provisioned release so peers can access it:', [
-        'pear seed ' + final.target.link
-      ])
-      hint('When ready to cut a production release, request signatures:', [
-        'pear multisig request ' + final.target.verlink
-      ])
+      hint('Keep the provisioned release available', ['pear seed <provision-link>'])
+      hint('Multisig for stakeholder-approved production', ['pear multisig keys get'])
     }
   }
 }

--- a/cmd/provision.js
+++ b/cmd/provision.js
@@ -101,7 +101,7 @@ module.exports = async function provision(cmd) {
         'pear provision ' + sourceVerlink + ' ' + targetLink + ' ' + productionVerlink
       ])
     } else if (final?.target) {
-      hint('Keep the provisioned release available', ['pear seed <provision-link>'])
+      hint('Keep the provisioned release available', ['pear seed <link>'])
       hint('Multisig for stakeholder-approved production', ['pear multisig keys get'])
     }
   }

--- a/cmd/provision.js
+++ b/cmd/provision.js
@@ -1,6 +1,6 @@
 'use strict'
 const context = require('../context')
-const { outputter, ansi, byteDiff } = require('../lib/terminal.js')
+const { outputter, ansi, byteDiff, hint } = require('../lib/terminal.js')
 const { ERR_INVALID_LINK } = require('pear-errors')
 const plink = require('pear-link')
 
@@ -55,18 +55,11 @@ const output = outputter('provision', {
   final: ({ target }) => {
     const dryRun = !target
     if (dryRun) return
-    const { verlink, hashlink, link } = target
+    const { verlink, hashlink } = target
     return {
       output: 'print',
       success: Infinity, // omit success tick
-      message:
-        '\nProvisioned:\n  Verlink: ' +
-        verlink +
-        '\n\n  Hashlink: ' +
-        hashlink +
-        '\n\nSeed with:\n\n   pear seed ' +
-        link +
-        '\n'
+      message: '\nProvisioned:\n  Verlink: ' + verlink + '\n\n  Hashlink: ' + hashlink + '\n'
     }
   },
   seeding: ({ cooloff, peers }) => {
@@ -97,5 +90,23 @@ module.exports = async function provision(cmd) {
       link: productionVerlink
     })
   }
-  await output(json, ipc.provision({ sourceVerlink, targetLink, productionVerlink, dryRun }))
+  const final = await output(
+    json,
+    ipc.provision({ sourceVerlink, targetLink, productionVerlink, dryRun })
+  )
+
+  if (!json) {
+    if (dryRun) {
+      hint('Dry run only - nothing was persisted. Once the diff looks right, provision for real:', [
+        'pear provision ' + sourceVerlink + ' ' + targetLink + ' ' + productionVerlink
+      ])
+    } else if (final?.target) {
+      hint('Seed the provisioned release so peers can access it:', [
+        'pear seed ' + final.target.link
+      ])
+      hint('When ready to cut a production release, request signatures:', [
+        'pear multisig request ' + final.target.verlink
+      ])
+    }
+  }
 }

--- a/cmd/stage.js
+++ b/cmd/stage.js
@@ -4,7 +4,7 @@ const os = require('bare-os')
 const { isAbsolute, resolve } = require('bare-path')
 const plink = require('pear-link')
 const { ERR_INVALID_INPUT } = require('pear-errors')
-const { outputter, ansi } = require('../lib/terminal.js')
+const { outputter, ansi, hint } = require('../lib/terminal.js')
 const { byteDiff } = require('../lib/terminal.js')
 const { cmdArgs } = require('../argv')
 
@@ -59,4 +59,15 @@ module.exports = async function stage(cmd) {
     cmdArgs
   })
   await output(json, stream)
+
+  if (!json) {
+    const target = link + (cmd.args.dir ? ' ' + cmd.args.dir : '')
+    if (dryRun) {
+      hint('Dry run only - nothing was persisted. Once the diff looks right, stage for real:', [
+        'pear stage ' + target
+      ])
+    } else {
+      hint('Seed the staged version so peers can access it:', ['pear seed ' + link])
+    }
+  }
 }

--- a/cmd/stage.js
+++ b/cmd/stage.js
@@ -61,13 +61,12 @@ module.exports = async function stage(cmd) {
   await output(json, stream)
 
   if (!json) {
-    const target = link + (cmd.args.dir ? ' ' + cmd.args.dir : '')
     if (dryRun) {
       hint('Dry run only - nothing was persisted. Once the diff looks right, stage for real:', [
-        'pear stage ' + target
+        'pear stage <link> <dir>'
       ])
     } else {
-      hint('Keep the staged version available', ['pear seed <stage-link>'])
+      hint('Keep the staged version available', ['pear seed <link>'])
       hint('Provision for prerelease, stakeholder preview, QA, or dogfooding', [
         'pear touch',
         'pear provision --dry-run <versioned-stage-link> <provision-link> <versioned-production-link>'

--- a/cmd/stage.js
+++ b/cmd/stage.js
@@ -67,7 +67,11 @@ module.exports = async function stage(cmd) {
         'pear stage ' + target
       ])
     } else {
-      hint('Seed the staged version so peers can access it:', ['pear seed ' + link])
+      hint('Keep the staged version available', ['pear seed <stage-link>'])
+      hint('Provision for prerelease, stakeholder preview, QA, or dogfooding', [
+        'pear touch',
+        'pear provision --dry-run <versioned-stage-link> <provision-link> <versioned-production-link>'
+      ])
     }
   }
 }

--- a/cmd/touch.js
+++ b/cmd/touch.js
@@ -61,9 +61,6 @@ module.exports = async function touch(cmd) {
         description: 'Production; stakeholder multisig, machine-independent, tamper-resistant'
       }
     ])
-    hint('Use the link above', [
-      'pear seed <link>',
-      'pear stage --dry-run <link> <deployment-directory>'
-    ])
+    hint('Use the link above', ['pear stage --dry-run <link> <dir>'])
   }
 }

--- a/cmd/touch.js
+++ b/cmd/touch.js
@@ -1,7 +1,7 @@
 'use strict'
 const { ERR_INVALID_INPUT } = require('pear-errors')
 const context = require('../context')
-const { outputter } = require('../lib/terminal.js')
+const { outputter, hint } = require('../lib/terminal.js')
 
 const output = outputter('touch', {
   final: ({ link }) => {
@@ -41,5 +41,29 @@ module.exports = async function touch(cmd) {
 
   const ipc = context.getIPC()
   const json = cmd.flags.json
-  await output({ json, ctrlTTY: false, log: (line) => console.log(line) }, ipc.touch({ keyPair }))
+  const final = await output(
+    { json, ctrlTTY: false, log: (line) => console.log(line) },
+    ipc.touch({ keyPair })
+  )
+
+  if (!json && final?.link) {
+    hint('Deployment operations', [
+      {
+        label: 'stage',
+        description: 'Local/dev checks, unsigned builds, branches, throwaways'
+      },
+      {
+        label: 'provision',
+        description: 'Prereleases, stakeholder preview, QA, dogfooding'
+      },
+      {
+        label: 'multisig',
+        description: 'Production; stakeholder multisig, machine-independent, tamper-resistant'
+      }
+    ])
+    hint('Use the link above', [
+      'pear seed <link>',
+      'pear stage --dry-run <link> <deployment-directory>'
+    ])
+  }
 }

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -60,7 +60,6 @@ ansi.dot = isWindows ? 'o' : '•'
 ansi.key = isWindows ? '>' : '🔑'
 ansi.down = isWindows ? '↓' : '⬇'
 ansi.up = isWindows ? '↑' : '⬆'
-ansi.arrow = isWindows ? '->' : '→'
 
 const stdio = new (class Stdio {
   static WriteStream = class FdWriteStream extends BareWritable {
@@ -263,15 +262,24 @@ function print(message, success) {
   console.log(`${typeof success !== 'undefined' ? indicator(success) : ''}${message}`)
 }
 
-// Onboarding guidance for the next step in a flow. Written to stderr so it never
+// Contextual onboarding guidance. Written to stderr so it never
 // pollutes stdout that scripts may parse (LINK=$(pear ...) / pear ... | cmd), and
 // callers suppress it under --json (the stable machine-readable contract).
-function hint(title, commands) {
-  const list = commands === undefined || commands === null ? [] : [].concat(commands)
+function hint(title, items) {
+  const list = items === undefined || items === null ? [] : [].concat(items)
   if (!title && list.length === 0) return
-  let out = ''
-  if (title) out += ansi.dim(ansi.arrow + ' ' + title) + '\n'
-  for (const command of list) out += '    ' + ansi.bold(command) + '\n'
+  const labels = list.filter((item) => typeof item === 'object')
+  const width = labels.reduce((max, { label = '' }) => Math.max(max, label.length), 0)
+  let out = '\n'
+  if (title) out += '  ' + ansi.gray(title) + '\n'
+  for (const item of list) {
+    if (typeof item === 'string') {
+      out += '    ' + ansi.dim('$ ' + item) + '\n'
+      continue
+    }
+    const { label = '', description = '' } = item
+    out += '    ' + ansi.bold(ansi.gray(label.padEnd(width))) + '  ' + ansi.dim(description) + '\n'
+  }
   stdio.err.write(out)
 }
 

--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -60,6 +60,7 @@ ansi.dot = isWindows ? 'o' : '•'
 ansi.key = isWindows ? '>' : '🔑'
 ansi.down = isWindows ? '↓' : '⬇'
 ansi.up = isWindows ? '↑' : '⬆'
+ansi.arrow = isWindows ? '->' : '→'
 
 const stdio = new (class Stdio {
   static WriteStream = class FdWriteStream extends BareWritable {
@@ -262,6 +263,18 @@ function print(message, success) {
   console.log(`${typeof success !== 'undefined' ? indicator(success) : ''}${message}`)
 }
 
+// Onboarding guidance for the next step in a flow. Written to stderr so it never
+// pollutes stdout that scripts may parse (LINK=$(pear ...) / pear ... | cmd), and
+// callers suppress it under --json (the stable machine-readable contract).
+function hint(title, commands) {
+  const list = commands === undefined || commands === null ? [] : [].concat(commands)
+  if (!title && list.length === 0) return
+  let out = ''
+  if (title) out += ansi.dim(ansi.arrow + ' ' + title) + '\n'
+  for (const command of list) out += '    ' + ansi.bold(command) + '\n'
+  stdio.err.write(out)
+}
+
 function byteDiff({ type, sizes, message }) {
   sizes = sizes.map((size) => (size > 0 ? '+' : '') + byteSize(size)).join(', ')
   print(indicator(type, 'diff') + ' ' + message + ' (' + sizes + ')')
@@ -413,6 +426,7 @@ module.exports = {
   indicator,
   status,
   print,
+  hint,
   outputter,
   isTTY,
   byteSize,


### PR DESCRIPTION
pear touch
```
  Deployment operations
    stage      Local/dev checks, unsigned builds, branches, throwaways
    provision  Prereleases, stakeholder preview, QA, dogfooding
    multisig   Production; stakeholder multisig, machine-independent, tamper-resistant

  Use the link above
    $ pear stage --dry-run <link> <dir>
```


pear stage --dry-run
```
  Dry run only - nothing was persisted. Once the diff looks right, stage for real:
    $ pear stage <link> <dir>
```


pear stage
```
  Keep the staged version available
    $ pear seed <link>

  Provision for prerelease, stakeholder preview, QA, or dogfooding
    $ pear touch
    $ pear provision --dry-run <versioned-stage-link> <provision-link> <versioned-production-link>
```


pear provision --dry-run
```
  Dry run only - nothing was persisted. Once the diff looks right, provision for real:
    $ pear provision <source-verlink> <target-link> <production-verlink>

```


pear provision
```
  Keep the provisioned release available
    $ pear seed <link>

  Multisig for stakeholder-approved production
    $ pear multisig keys get

pear multisig keys get

  Add this public key to multisig.publicKeys in pear.json, then get the multisig link:
    $ pear multisig link
```


pear multisig link
```
  Before requesting signatures, set this as package.json upgrade and produce a seeded provisioned build against the multisig link:
    $ pear multisig request <versioned-provision-link>
```


pear multisig request
```
  Send this request to each signer. Each signs it with their key:
    $ pear multisig sign <request>

  Once signers return their responses, verify them:
    $ pear multisig verify <source-link> <request> <response> [<response> ...]
```


pear multisig sign
`  Send this response back to the release coordinator, who verifies and commits it.`

pear multisig verify without responses
```
  Request verified. Once signers return their responses, verify again with them:
    $ pear multisig verify <source-link> <request> <response> [<response> ...]
```


pear multisig verify with responses
```
  If verification passed, commit to go live:
    $ pear multisig commit <source-link> <request> <response> [<response> ...]
```


pear multisig commit
```
  The commit is not safe until peers seed it. Seed the multisig link:
    $ pear seed <link>
```