### PR TITLE
Skip cores with 0 contiguousLength

### DIFF
--- a/cmd/cores.js
+++ b/cmd/cores.js
@@ -15,5 +15,6 @@ const output = outputter('cores', {
 module.exports = async function cores(cmd) {
   const ipc = context.getIPC()
   const json = cmd.flags.json
-  await output({ json, ctrlTTY: false, log: (line) => console.log(line) }, ipc.cores({}))
+  const allCores = cmd.flags.allCores
+  await output({ json, ctrlTTY: false, log: (line) => console.log(line) }, ipc.cores({ allCores }))
 }

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -362,6 +362,7 @@ module.exports = async (ipc, argv = cmdArgs) => {
     'cores',
     summary('List platform cores'),
     description`List platform corestore cores`,
+    flag('--all-cores', 'List all cores, including empty cores'),
     flag('--json', 'Newline delimited JSON output'),
     commands.cores
   )

--- a/subsystems/sidecar/ops/cores.js
+++ b/subsystems/sidecar/ops/cores.js
@@ -11,6 +11,8 @@ module.exports = class Cores extends Opstream {
   async #op(params) {
     LOG.info('cores', 'Enumerating cores')
 
+    const allCores = params.allCores
+
     const { sidecar } = this
 
     const discoveryKeys = []
@@ -34,7 +36,7 @@ module.exports = class Cores extends Opstream {
       })
       await core.ready()
       const coreInfo = await core.info()
-      if (coreInfo.contiguousLength === 0) {
+      if (!allCores && coreInfo.contiguousLength === 0) {
         LOG.trace('cores', `Skipping empty core ${link}`)
         continue
       }

--- a/subsystems/sidecar/ops/cores.js
+++ b/subsystems/sidecar/ops/cores.js
@@ -9,24 +9,43 @@ module.exports = class Cores extends Opstream {
   }
 
   async #op(params) {
+    LOG.info('cores', 'Enumerating cores')
+
     const { sidecar } = this
 
     const discoveryKeys = []
     for await (const dkey of sidecar.corestore.list()) discoveryKeys.push(dkey)
 
     let writableCount = 0
+    let count = 0
+
+    LOG.info('cores', `Found ${discoveryKeys.length} discovery keys`)
 
     for (const discoveryKey of discoveryKeys) {
       const dkey = hypercoreid.encode(discoveryKey)
       const info = await sidecar.corestore.storage.getInfo(discoveryKey)
+
+      const key = info.auth.key
+      const link = plink.serialize({ drive: { key } })
+
+      const core = sidecar.corestore.get({
+        discoveryKey: info.discoveryKey,
+        active: false
+      })
+      await core.ready()
+      const coreInfo = await core.info()
+      if (coreInfo.contiguousLength === 0) {
+        LOG.trace('cores', `Skipping empty core ${link}`)
+        continue
+      }
+
+      ++count
 
       const writable = Boolean(info.auth.keyPair)
       if (writable) {
         ++writableCount
       }
 
-      const key = info.auth.key
-      const link = plink.serialize({ drive: { key } })
       this.push({
         tag: 'core',
         data: {
@@ -36,6 +55,6 @@ module.exports = class Cores extends Opstream {
       })
     }
 
-    this.final = { count: discoveryKeys.length, writable: writableCount }
+    this.final = { count, writable: writableCount }
   }
 }


### PR DESCRIPTION
Tested after generating some cores from https://github.com/holepunchto/pear/pull/1149 which has been GC-ed:

```
$ pear cores
pear://smw4thqaqed9iq6bae7a9cxd4fesruixgkafe38jny33ahs33igy
pear://3qsiuoirybxkehuurdjt1tfpeka9734twg9dkrf7jekp17ggqh8y
pear://6yjpy3p1ip5mwox66sk66b7od5f61zrxmoe3am6me8q9omeh4fho
Total cores: 3 | Writable: 0
```

```
$ pear cores --all-cores
pear://j6kahe85untktggogedssgi7dmkwq1gfujoh7ncs3m3p4ydu3xyo
pear://smw4thqaqed9iq6bae7a9cxd4fesruixgkafe38jny33ahs33igy
pear://3qsiuoirybxkehuurdjt1tfpeka9734twg9dkrf7jekp17ggqh8y
pear://6yjpy3p1ip5mwox66sk66b7od5f61zrxmoe3am6me8q9omeh4fho
pear://41nbqbpdn9tk7tksr8egnpp3gseix5hztwtjtypxb1yt5acn8fuy
pear://pzu7imo641trghd1du53nj3dwyq4fxz5axbpge5k3gm19wey68mo
Total cores: 6 | Writable: 0
```

`pear/pear.log`:
```
INF   2026-07-31T09:20:05.056Z [ cores ] Enumerating cores
INF   2026-07-31T09:20:05.056Z [ cores ] Found 6 discovery keys
TRC   2026-07-31T09:20:05.058Z [ cores ] Skipping empty core pear://j6kahe85untktggogedssgi7dmkwq1gfujoh7ncs3m3p4ydu3xyo
TRC   2026-07-31T09:20:05.060Z [ cores ] Skipping empty core pear://41nbqbpdn9tk7tksr8egnpp3gseix5hztwtjtypxb1yt5acn8fuy
TRC   2026-07-31T09:20:05.060Z [ cores ] Skipping empty core pear://pzu7imo641trghd1du53nj3dwyq4fxz5axbpge5k3gm19wey68mo
```