### PR TITLE
fix: `pear <command> --json` to emit valid output for parsers

### DIFF
--- a/lib/terminal.js
+++ b/lib/terminal.js
@@ -288,7 +288,9 @@ const outputter =
   (cmd, taggers = {}) =>
   (opts, stream, info = {}) => {
     if (Array.isArray(stream)) stream = Readable.from(stream)
-    const asTTY = opts.ctrlTTY ?? isTTY
+    if (typeof opts === 'boolean' || typeof opts === 'function') opts = { json: opts }
+    const { json = false, log } = opts
+    const asTTY = !json && (opts.ctrlTTY ?? isTTY)
     if (asTTY) stdio.out.write(ansi.hideCursor())
     const dereg = asTTY
       ? gracedown(() => {
@@ -296,8 +298,6 @@ const outputter =
           stdio.out.write(ansi.showCursor())
         })
       : null
-    if (typeof opts === 'boolean' || typeof opts === 'function') opts = { json: opts }
-    const { json = false, log } = opts
     const promise = opwait(stream, ({ tag, data }) => {
       if (json) {
         const replacer = typeof json === 'function' ? json : null


### PR DESCRIPTION
`--json` was still entering TTY mode (now disabled when `--json` is passed), was emitting escape character `ESC[?25l` (`stdio.out.write(ansi.hideCursor()`) which breaks JSON parsing.

Affected commands, fixed in this PR:

```js
  pear stage --json
  pear provision --json
  pear info --json
  pear dump --json
  pear data --json dht
  pear changelog --json
  pear versions --json
  pear gc --json cores
```

error:

```bash
➜  ~ pear info --json | jq -r 'select(.tag == "info") | .data.version'

jq: parse error: Invalid numeric literal at line 1, column 2
2026-08-04T06:30:01.139Z ERR [ cli ] Exiting due to uncaught exception FileError: EPIPE: broken pipe, writev 1
    at WritableState.afterDestroy (bare:/app.bundle/node_modules/streamx/index.js:572:19)
    at FdWriteStream._destroy (bare:/app.bundle/node_modules/streamx/index.js:725:5)
    at WritableState.updateNonPrimary (bare:/app.bundle/node_modules/streamx/index.js:223:16)
    at WritableState.update (bare:/app.bundle/node_modules/streamx/index.js:205:72)
    at WritableState.updateWriteNT (bare:/app.bundle/node_modules/streamx/index.js:635:10) {
  code: 'EPIPE',
  operation: 'writev',
  fd: 1
}
```

---

Fixed:

<img width="1004" height="125" alt="image" src="https://github.com/user-attachments/assets/a4b8c990-195f-41f5-ba83-dee5dcd6ae58" />


