### PR TITLE
simplify get corestore

### DIFF
--- a/subsystems/sidecar/ops/cores.js
+++ b/subsystems/sidecar/ops/cores.js
@@ -16,9 +16,7 @@ module.exports = class Cores extends Opstream {
 
     const { sidecar, session } = this
 
-    const corestore = this.sidecar.getCorestore().session({ writable: false })
-    await corestore.ready()
-    session.add(corestore)
+    const corestore = await session.add(sidecar.getCorestore())
 
     const discoveryKeys = []
     for await (const dkey of corestore.list()) discoveryKeys.push(dkey)


### PR DESCRIPTION
https://github.com/holepunchto/pear/pull/1176 <-

* removed `await resource.ready()` because it's already called inside `session.add()`
* preserves writable: false (default)