### PR TITLE
Use PATH env var on Windows in make script

### DIFF
--- a/scripts/make.js
+++ b/scripts/make.js
@@ -39,7 +39,9 @@ async function make() {
   if (sign) {
     signFlags.push('--sign')
     if (env.WINDOWS_CERT_SHA1) {
-      if (isWindows) extraEnv.Path = `${await findSigntoolDir()};${env.Path}`
+      // On Windows, env keys are case-insensitive, but Node.js resolves duplicate variants lexicographically.
+      // Socket Firewall sets PATH, so use PATH consistently to avoid Node.js dropping the Path variant.
+      if (isWindows) extraEnv.PATH = `${await findSigntoolDir()};${env.PATH}`
       signFlags.push('--thumbprint', env.WINDOWS_CERT_SHA1)
     }
 

--- a/scripts/make.js
+++ b/scripts/make.js
@@ -54,8 +54,6 @@ async function make() {
   }
 
   console.log('Running bare-build for channel', channel, sign ? 'with signing' : 'without signing')
-  const buildEnv = { ...env, ...extraEnv }
-  console.log('buildEnv', buildEnv)
   const build = spawn(
     'bare-build',
     [

--- a/scripts/make.js
+++ b/scripts/make.js
@@ -52,6 +52,8 @@ async function make() {
   }
 
   console.log('Running bare-build for channel', channel, sign ? 'with signing' : 'without signing')
+  const buildEnv = { ...env, ...extraEnv }
+  console.log('buildEnv', buildEnv)
   const build = spawn(
     'bare-build',
     [


### PR DESCRIPTION
There are cases where the PATH environment variable may be set on Windows (Socket Firewall sets it). Modifying `Path` alone in such situations will pass the unmodified `PATH` env var to `bare-build` and it won't be able to find `signtool`. This change uses the lexicographically smallest variant of `path`, which is `PATH`, consistently on Windows, so that the path modification works for all variants of the path env var.

For reference, the Node.js child process [docs](https://nodejs.org/api/child_process.html#:~:text=On%20Windows%2C%20environment,and%20Path.) says:
> On Windows, environment variables are case-insensitive. Node.js lexicographically sorts the env keys and uses the first one that case-insensitively matches. Only first (in lexicographic order) entry will be passed to the subprocess. This might lead to issues on Windows when passing objects to the `env` option that have multiple variants of the same key, such as `PATH` and `Path`.

The pear-ci-build main branch is able to build this change successfully on Windows: https://github.com/holepunchto/pear-ci-build/actions/runs/32220331426