### PR TITLE
`$ pear cores` improvements

### DIFF
--- a/cmd/cores.js
+++ b/cmd/cores.js
@@ -1,21 +1,24 @@
 'use strict'
 const context = require('../context')
-const { outputter } = require('../lib/terminal.js')
+const { outputter, ansi, byteSize } = require('../lib/terminal.js')
 
-const TYPES = ['[core]', '[blobs]']
+const TYPES = ['core', 'blobs']
 const TYPE_WIDTH = Math.max(...TYPES.map((type) => type.length))
 
 const output = outputter('cores', {
   core: (data, info) => {
     info.cores.push(data)
   },
-  final: ({ count, writable }, info) => ({
+  final: ({ count, writable, byteLength }, info) => ({
     output: 'print',
     success: Infinity, // omit success ansi tick
     message:
       count > 0
-        ? [...table(info.cores), `Total cores: ${count} | Writable: ${writable}`]
-        : 'No cores'
+        ? [
+            ...table(info.cores),
+            `Total cores: ${count}${ansi.gray(` (writable: ${writable})`)}\nTotal size:  ${byteSize(byteLength)}`
+          ]
+        : '[ No cores ]'
   }),
   error: ({ code, message, stack }) => `Error (code: ${code || 'none'}) ${message} ${stack}`
 })
@@ -32,12 +35,39 @@ module.exports = async function cores(cmd) {
 }
 
 function table(cores) {
-  const nameWidth = cores.reduce((max, { name }) => Math.max(max, label(name).length), 0)
-  return sort(cores).map(({ link, name, blobs, length, writable }) => {
-    const type = blobs ? '[blobs]' : '[core]'
-    const meta = writable ? `(length: ${length}, writable)` : `(length: ${length})`
-    return `${label(name).padEnd(nameWidth)} ${type.padEnd(TYPE_WIDTH)} ${link} ${meta}`
-  })
+  cores = sort(cores)
+  const nameWidth = cores.reduce(
+    (max, { name }) => Math.max(max, label(name).length),
+    'NAME'.length
+  )
+  const linkWidth = cores.reduce((max, { link }) => Math.max(max, link.length), 'LINK'.length)
+  const lengthWidth = cores.reduce(
+    (max, { length }) => Math.max(max, String(length).length),
+    'LENGTH'.length
+  )
+  const sizeWidth = cores.reduce(
+    (max, { byteLength }) => Math.max(max, byteSize(byteLength).length),
+    'SIZE'.length
+  )
+  const header = `${'NAME'.padEnd(nameWidth)}  ${'TYPE'.padEnd(TYPE_WIDTH)}  ${'LINK'.padEnd(linkWidth)}  ${'LENGTH'.padEnd(lengthWidth)}  WRITABLE  ${'SIZE'.padEnd(sizeWidth)}`
+  const separator = ansi.gray('─'.repeat(header.length + 2))
+  return [
+    '\n ' + ansi.bold(header),
+    separator,
+    ...cores.map(({ link, name, blobs, drive, length, writable, byteLength }, index) => {
+      const type = blobs ? 'blobs' : 'core'
+      const nameLabel = label(name).padEnd(nameWidth)
+      const sizeLabel = byteSize(byteLength).padEnd(sizeWidth)
+      const prefix = index > 0 && drive !== cores[index - 1].drive ? separator + '\n' : ''
+      const writableLabel = (writable ? '✔' : '').padEnd('WRITABLE'.length)
+      const row = `${nameLabel}  ${type.padEnd(TYPE_WIDTH)}  ${link.padEnd(linkWidth)}  ${String(length).padEnd(lengthWidth)}  `
+      if (blobs) {
+        return `${prefix} ${ansi.gray(row + writableLabel + '  ' + sizeLabel)}`
+      }
+      return `${prefix} ${row}${writableLabel}  ${sizeLabel}`
+    }),
+    separator
+  ]
 }
 
 function sort(cores) {

--- a/cmd/cores.js
+++ b/cmd/cores.js
@@ -38,18 +38,18 @@ function table(cores) {
   cores = sort(cores)
   const nameWidth = cores.reduce(
     (max, { name }) => Math.max(max, label(name).length),
-    'NAME'.length
+    'Name'.length
   )
-  const linkWidth = cores.reduce((max, { link }) => Math.max(max, link.length), 'LINK'.length)
+  const linkWidth = cores.reduce((max, { link }) => Math.max(max, link.length), 'Link'.length)
   const lengthWidth = cores.reduce(
     (max, { length }) => Math.max(max, String(length).length),
-    'LENGTH'.length
+    'Length'.length
   )
   const sizeWidth = cores.reduce(
     (max, { byteLength }) => Math.max(max, byteSize(byteLength).length),
-    'SIZE'.length
+    'Size'.length
   )
-  const header = `${'NAME'.padEnd(nameWidth)}  ${'TYPE'.padEnd(TYPE_WIDTH)}  ${'LINK'.padEnd(linkWidth)}  ${'LENGTH'.padEnd(lengthWidth)}  WRITABLE  ${'SIZE'.padEnd(sizeWidth)}`
+  const header = `${'Name'.padEnd(nameWidth)}  ${'Type'.padEnd(TYPE_WIDTH)}  ${'Link'.padEnd(linkWidth)}  ${'Length'.padEnd(lengthWidth)}  Writable  ${'Size'.padEnd(sizeWidth)}`
   const separator = ansi.gray('─'.repeat(header.length + 2))
   return [
     '\n ' + ansi.bold(header),
@@ -59,7 +59,7 @@ function table(cores) {
       const nameLabel = label(name).padEnd(nameWidth)
       const sizeLabel = byteSize(byteLength).padEnd(sizeWidth)
       const prefix = index > 0 && drive !== cores[index - 1].drive ? separator + '\n' : ''
-      const writableLabel = (writable ? '✔' : '').padEnd('WRITABLE'.length)
+      const writableLabel = (writable ? '✔' : '').padEnd('Writable'.length)
       const row = `${nameLabel}  ${type.padEnd(TYPE_WIDTH)}  ${link.padEnd(linkWidth)}  ${String(length).padEnd(lengthWidth)}  `
       if (blobs) {
         return `${prefix} ${ansi.gray(row + writableLabel + '  ' + sizeLabel)}`

--- a/subsystems/sidecar/ops/cores.js
+++ b/subsystems/sidecar/ops/cores.js
@@ -23,6 +23,7 @@ module.exports = class Cores extends Opstream {
 
     let writableCount = 0
     let count = 0
+    let totalByteLength = 0
 
     LOG.info('cores', `Found ${discoveryKeys.length} discovery keys`)
 
@@ -48,6 +49,7 @@ module.exports = class Cores extends Opstream {
       }
 
       ++count
+      totalByteLength += coreInfo.byteLength
 
       const writable = Boolean(info.auth.keyPair)
       if (writable) {
@@ -56,7 +58,7 @@ module.exports = class Cores extends Opstream {
 
       const contentLink = getContentLink(info)
       if (contentLink !== null) contentLinks.set(contentLink, link)
-      cores.set(link, { key, writable, length: core.length })
+      cores.set(link, { key, writable, length: core.length, byteLength: coreInfo.byteLength })
 
       core.close()
     }
@@ -72,7 +74,7 @@ module.exports = class Cores extends Opstream {
       if (names.has(link)) names.set(contentLink, names.get(link))
     }
 
-    for (const [link, { writable, length }] of cores) {
+    for (const [link, { writable, length, byteLength }] of cores) {
       const blobs = contentLinks.has(link)
       this.push({
         tag: 'core',
@@ -80,6 +82,7 @@ module.exports = class Cores extends Opstream {
           link,
           writable,
           length,
+          byteLength,
           blobs,
           drive: blobs ? contentLinks.get(link) : link,
           name: names.get(link) ?? null
@@ -87,7 +90,7 @@ module.exports = class Cores extends Opstream {
       })
     }
 
-    this.final = { count, writable: writableCount }
+    this.final = { count, writable: writableCount, byteLength: totalByteLength }
   }
 }
 

--- a/test/12-cores.test.js
+++ b/test/12-cores.test.js
@@ -3,7 +3,7 @@ const test = require('brittle')
 const Helper = require('./helper')
 
 test('pear cores lists default cores', async ({ teardown, plan, is, ok }) => {
-  plan(7)
+  plan(9)
   const helper = new Helper()
   teardown(() => helper.close(), { order: Infinity })
   await helper.ready()
@@ -14,6 +14,7 @@ test('pear cores lists default cores', async ({ teardown, plan, is, ok }) => {
   ok(/^pear:\/\/[a-z0-9]{52}$/.test(core.link))
   is(typeof core.writable, 'boolean')
   is(typeof core.blobs, 'boolean')
+  is(typeof core.byteLength, 'number')
   ok(Object.hasOwn(core, 'name'))
 
   const result = await cores.final
@@ -21,6 +22,7 @@ test('pear cores lists default cores', async ({ teardown, plan, is, ok }) => {
   is(result.success, true)
   ok(result.count > 0)
   ok(result.writable <= result.count)
+  is(typeof result.byteLength, 'number')
 })
 
 test('pear cores names cores and groups blobs with their metadata core', async (t) => {


### PR DESCRIPTION
* ui: group related core+blobs together in the same row
* ui: improved layout to be more readable
* feat: show byte sizes per core and total sum

---

### main (current)

<img width="871" height="429" alt="image" src="https://github.com/user-attachments/assets/9f00d1ba-873c-42db-9605-6dac33f1b726" />

---

### PR result

<img width="853" height="429" alt="image" src="https://github.com/user-attachments/assets/04ea22e8-4d94-4868-972e-584ea2c08003" />


---

### footer

<img width="858" height="179" alt="image" src="https://github.com/user-attachments/assets/a3291e77-0225-47ea-bd94-0b0533eb0fc0" />
