### PR TITLE
stage without package.json

### DIFF
--- a/cmd/index.js
+++ b/cmd/index.js
@@ -112,6 +112,7 @@ module.exports = async (ipc, argv = cmdArgs) => {
       '--truncate <n>',
       'Advanced. Truncate the project to this version length. Destructive — later versions are dropped'
     ).hint('n is the length segment of a verlink (pear://<fork>.<length>.<key>).'),
+    flag('--skip-package-json', 'Stage a folder without package.json'),
     flag('--json', 'Newline delimited JSON output'),
     commands.stage
   )

--- a/cmd/index.js
+++ b/cmd/index.js
@@ -94,7 +94,7 @@ module.exports = async (ipc, argv = cmdArgs) => {
       'If you pass a versioned verlink, only its key is used — staging always targets the current head, ignoring the version segment.'
     ),
     arg('[dir=.]', 'Project directory to stage from').hint(
-      'Defaults to the directory you run the command from. If it has no package.json, Pear searches upward through parent directories for one.'
+      'Defaults to the directory you run the command from.'
     ),
     flag('--dry-run|-d', 'Execute a stage without writing').hint(
       'Does not guard --truncate: if --truncate is also given, the drive is truncated for real before any dry-run check runs.'
@@ -640,6 +640,7 @@ module.exports = async (ipc, argv = cmdArgs) => {
         ['ERR_LEGACY', messageOnly],
         ['ERR_INVALID_TEMPLATE', messageOnly],
         ['ERR_INVALID_PROJECT_DIR', messageOnly],
+        ['ERR_INVALID_MANIFEST', messageOnly],
         ['ERR_DIR_NONEMPTY', messageOnly],
         ['ERR_NOT_FOUND', messageOnly],
         ['ERR_OPERATION_FAILED', opFail]

--- a/cmd/stage.js
+++ b/cmd/stage.js
@@ -1,16 +1,18 @@
 'use strict'
 const context = require('../context')
 const os = require('bare-os')
+const fs = require('bare-fs')
+const path = require('bare-path')
 const { isAbsolute, resolve } = require('bare-path')
 const { ERR_INVALID_INPUT } = require('pear-errors')
-const { outputter, ansi, hint } = require('../lib/terminal.js')
+const { outputter, ansi, hint, confirm } = require('../lib/terminal.js')
 const { byteDiff } = require('../lib/terminal.js')
 const { cmdArgs } = require('../argv')
 const { parse } = require('../lib/link')
 
 const output = outputter('stage', {
-  staging: ({ name, link, verlink, current }) => {
-    return `\n${ansi.pear} Staging ${name}\n\n[  ${ansi.dim(link)}  ]\n${ansi.gray(ansi.dim(verlink))}\n\nCurrent: ${current}\n`
+  staging: ({ name, link, verlink, current, dir }) => {
+    return `\n${ansi.pear} Staging ${name || dir}\n\n[  ${ansi.dim(link)}  ]\n${ansi.gray(ansi.dim(verlink))}\n\nCurrent: ${current}\n`
   },
   skipping: ({ reason }) => 'Skipping (' + reason + ')',
   dry: 'NOTE: This is a dry run, no changes will be persisted.\n',
@@ -31,6 +33,8 @@ module.exports = async function stage(cmd) {
   const ipc = context.getIPC()
   const { dryRun, bare, json, ignore, purge, name, only } = cmd.flags
   let truncate = cmd.flags.truncate
+  let skipPackageJson = cmd.flags.skipPackageJson
+
   if (truncate !== undefined) {
     truncate = +truncate
     if (Number.isInteger(truncate) === false) {
@@ -43,6 +47,21 @@ module.exports = async function stage(cmd) {
 
   let { dir = cwd } = cmd.args
   if (isAbsolute(dir) === false) dir = dir ? resolve(os.cwd(), dir) : os.cwd()
+
+  const pkg = await localPkg(dir)
+
+  if (!pkg) {
+    const dialog =
+      ansi.warning +
+      `The folder does not contain a valid package.json file. To confirm type "STAGE"\n`
+    const ask = `Stage folder without package.json`
+    const delim = '?'
+    const validation = (value) => value === 'STAGE'
+    const msg = '\n' + ansi.cross + ' uppercase STAGE to confirm\n'
+    await confirm(dialog, ask, delim, validation, msg)
+    skipPackageJson = true
+  }
+
   const id = Bare.pid
   const stream = ipc.stage({
     id,
@@ -54,7 +73,9 @@ module.exports = async function stage(cmd) {
     purge,
     name,
     truncate,
+    skipPackageJson,
     only,
+    pkg,
     cmdArgs
   })
   await output(json, stream)
@@ -73,4 +94,10 @@ module.exports = async function stage(cmd) {
       ])
     }
   }
+}
+
+async function localPkg(dir) {
+  try {
+    return JSON.parse(await fs.promises.readFile(path.join(dir, 'package.json')))
+  } catch {}
 }

--- a/cmd/stage.js
+++ b/cmd/stage.js
@@ -31,9 +31,8 @@ const output = outputter('stage', {
 
 module.exports = async function stage(cmd) {
   const ipc = context.getIPC()
-  const { dryRun, bare, json, ignore, purge, name, only } = cmd.flags
+  const { dryRun, bare, json, ignore, purge, name, only, skipPackageJson } = cmd.flags
   let truncate = cmd.flags.truncate
-  let skipPackageJson = cmd.flags.skipPackageJson
 
   if (truncate !== undefined) {
     truncate = +truncate
@@ -50,7 +49,7 @@ module.exports = async function stage(cmd) {
 
   const pkg = await localPkg(dir)
 
-  if (!pkg) {
+  if (!pkg && !skipPackageJson) {
     const dialog =
       ansi.warning +
       `The folder does not contain a valid package.json file. To confirm type "STAGE"\n`
@@ -59,7 +58,6 @@ module.exports = async function stage(cmd) {
     const validation = (value) => value === 'STAGE'
     const msg = '\n' + ansi.cross + ' uppercase STAGE to confirm\n'
     await confirm(dialog, ask, delim, validation, msg)
-    skipPackageJson = true
   }
 
   const id = Bare.pid
@@ -73,7 +71,6 @@ module.exports = async function stage(cmd) {
     purge,
     name,
     truncate,
-    skipPackageJson,
     only,
     pkg,
     cmdArgs

--- a/cmd/stage.js
+++ b/cmd/stage.js
@@ -1,14 +1,13 @@
 'use strict'
 const context = require('../context')
 const os = require('bare-os')
-const fs = require('bare-fs')
-const path = require('bare-path')
 const { isAbsolute, resolve } = require('bare-path')
-const { ERR_INVALID_INPUT } = require('pear-errors')
-const { outputter, ansi, hint, confirm } = require('../lib/terminal.js')
+const { ERR_INVALID_INPUT, ERR_INVALID_PROJECT_DIR } = require('pear-errors')
+const { outputter, ansi, hint, confirm, isTTY } = require('../lib/terminal.js')
 const { byteDiff } = require('../lib/terminal.js')
 const { cmdArgs } = require('../argv')
 const { parse } = require('../lib/link')
+const { localPkg } = require('../lib/package')
 
 const output = outputter('stage', {
   staging: ({ name, link, verlink, current, dir }) => {
@@ -50,6 +49,11 @@ module.exports = async function stage(cmd) {
   const pkg = await localPkg(dir)
 
   if (!pkg && !skipPackageJson) {
+    if (json || isTTY === false) {
+      throw ERR_INVALID_PROJECT_DIR(
+        `package.json not found in ${dir}. Pass --skip-package-json to stage without one`
+      )
+    }
     const dialog =
       ansi.warning +
       `The folder does not contain a valid package.json file. To confirm type "STAGE"\n`
@@ -91,10 +95,4 @@ module.exports = async function stage(cmd) {
       ])
     }
   }
-}
-
-async function localPkg(dir) {
-  try {
-    return JSON.parse(await fs.promises.readFile(path.join(dir, 'package.json')))
-  } catch {}
 }

--- a/lib/package.js
+++ b/lib/package.js
@@ -1,0 +1,39 @@
+'use strict'
+const fs = require('bare-fs')
+const path = require('bare-path')
+const { ERR_INVALID_PROJECT_DIR, ERR_INVALID_MANIFEST } = require('pear-errors')
+
+async function localPkg(dir) {
+  await validate(dir)
+  let manifest = null
+  try {
+    manifest = await fs.promises.readFile(path.join(dir, 'package.json'))
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw ERR_INVALID_PROJECT_DIR(`package.json in ${dir} could not be read: ${err.message}`)
+    }
+  }
+  if (manifest === null) return
+  let pkg = null
+  try {
+    pkg = JSON.parse(manifest)
+  } catch (err) {
+    throw ERR_INVALID_MANIFEST(`package.json in ${dir} is not a valid JSON object`)
+  }
+  if (pkg === null || typeof pkg !== 'object' || Array.isArray(pkg)) {
+    throw ERR_INVALID_MANIFEST(`package.json in ${dir} is invalid: not a JSON object`)
+  }
+  return pkg
+}
+
+async function validate(dir) {
+  let stat = null
+  try {
+    stat = await fs.promises.stat(dir)
+  } catch {
+    throw ERR_INVALID_PROJECT_DIR(`${dir} not found`)
+  }
+  if (stat.isDirectory() === false) throw ERR_INVALID_PROJECT_DIR(`${dir} is not a directory`)
+}
+
+module.exports = { validate, localPkg }

--- a/subsystems/sidecar/ops/stage.js
+++ b/subsystems/sidecar/ops/stage.js
@@ -3,6 +3,7 @@ const LocalDrive = require('localdrive')
 const unixPathResolve = require('unix-path-resolve')
 const plink = require('pear-link')
 const ReadyResource = require('ready-resource')
+const fs = require('bare-fs')
 const path = require('bare-path')
 const Opstream = require('../lib/opstream')
 const Hyperdrive = require('hyperdrive')
@@ -16,6 +17,8 @@ module.exports = class Stage extends Opstream {
   async #op({ link, dir, dryRun, truncate, ignore, purge, only, pkg }) {
     const { session, sidecar } = this
     const parsed = parse(link)
+
+    pkg = pkg || (await localPkg(dir))
 
     const options = pkg?.pear ?? {}
 
@@ -239,5 +242,13 @@ class GlobDrive extends ReadyResource {
       return false
     }
     return this.ignore
+  }
+}
+
+async function localPkg(dir) {
+  try {
+    return JSON.parse(await fs.promises.readFile(path.join(dir, 'package.json')))
+  } catch (err) {
+    LOG.error(err)
   }
 }

--- a/subsystems/sidecar/ops/stage.js
+++ b/subsystems/sidecar/ops/stage.js
@@ -3,11 +3,10 @@ const LocalDrive = require('localdrive')
 const unixPathResolve = require('unix-path-resolve')
 const plink = require('pear-link')
 const ReadyResource = require('ready-resource')
-const fs = require('bare-fs')
-const path = require('bare-path')
 const Opstream = require('../lib/opstream')
 const Hyperdrive = require('hyperdrive')
 const { parse } = require('../../../lib/link')
+const { localPkg, validate } = require('../../../lib/package')
 
 module.exports = class Stage extends Opstream {
   constructor(...args) {
@@ -17,6 +16,7 @@ module.exports = class Stage extends Opstream {
   async #op({ link, dir, dryRun, truncate, ignore, purge, only, pkg }) {
     const { session, sidecar } = this
     const parsed = parse(link)
+    await validate(dir)
 
     pkg = pkg || (await localPkg(dir))
 
@@ -242,13 +242,5 @@ class GlobDrive extends ReadyResource {
       return false
     }
     return this.ignore
-  }
-}
-
-async function localPkg(dir) {
-  try {
-    return JSON.parse(await fs.promises.readFile(path.join(dir, 'package.json')))
-  } catch (err) {
-    LOG.error(err)
   }
 }

--- a/subsystems/sidecar/ops/stage.js
+++ b/subsystems/sidecar/ops/stage.js
@@ -1,10 +1,8 @@
 'use strict'
 const LocalDrive = require('localdrive')
 const unixPathResolve = require('unix-path-resolve')
-const { ERR_INVALID_PROJECT_DIR } = require('pear-errors')
 const plink = require('pear-link')
 const ReadyResource = require('ready-resource')
-const fs = require('bare-fs')
 const path = require('bare-path')
 const Opstream = require('../lib/opstream')
 const Hyperdrive = require('hyperdrive')
@@ -15,16 +13,9 @@ module.exports = class Stage extends Opstream {
     super((...args) => this.#op(...args), ...args)
   }
 
-  async #op({ link, dir, dryRun, truncate, ignore, purge, only }) {
+  async #op({ link, dir, dryRun, truncate, ignore, purge, only, pkg }) {
     const { session, sidecar } = this
     const parsed = parse(link)
-
-    const { dir: pkgDir, pkg } = await localPkg(dir)
-    if (pkg === null) {
-      throw ERR_INVALID_PROJECT_DIR(
-        `"package.json not found from: ${dir}. Pear project must have a package.json`
-      )
-    }
 
     const options = pkg?.pear ?? {}
 
@@ -69,12 +60,12 @@ module.exports = class Stage extends Opstream {
         link: applink,
         verlink: verlink,
         current: currentVersion,
-        dir: pkgDir
+        dir
       }
     })
 
     if (dryRun) this.push({ tag: 'dry' })
-    const src = new LocalDrive(pkgDir, {
+    const src = new LocalDrive(dir, {
       followExternalLinks: true
     })
 
@@ -165,20 +156,6 @@ module.exports = class Stage extends Opstream {
         })
       }
     })
-  }
-}
-
-async function localPkg(dir) {
-  try {
-    const pkg = JSON.parse(await fs.promises.readFile(path.join(dir, 'package.json')))
-    return { dir, pkg }
-  } catch (err) {
-    if (err.code !== 'ENOENT' && err.code !== 'EISDIR' && err.code !== 'ENOTDIR') throw err
-    const parent = path.dirname(dir)
-    if (parent === dir || path.resolve(dir) === path.resolve(parent)) {
-      return { dir: null, pkg: null }
-    }
-    return localPkg(parent)
   }
 }
 

--- a/test/stage.test.js
+++ b/test/stage.test.js
@@ -1,5 +1,6 @@
 'use strict'
 const test = require('brittle')
+const path = require('bare-path')
 const Localdrive = require('localdrive')
 const Helper = require('./helper')
 
@@ -550,4 +551,174 @@ test('pear stage keeps the same key when restaging with new name', async ({
   is(addendumB.key, touchedKey, 'restaged key matches touched link key')
   is(addendumA.key, addendumB.key, 'restaging keeps the same app key')
   ok(addendumB.version > addendumA.version, 'restaging increments app version')
+})
+
+test('pear stage folder without package.json', async ({ teardown, ok, is, tmp }) => {
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+
+  const tmpdir = await tmp()
+  const to = new Localdrive(tmpdir)
+  await to.put('/index.js', 'module.exports = {}\n')
+
+  const link = await Helper.touchLink(helper)
+  const staging = helper.stage({ link, dir: tmpdir, dryRun: false })
+  teardown(() => Helper.teardownStream(staging))
+
+  const stagedFiles = []
+  staging.on('data', (data) => {
+    if (data?.tag === 'byte-diff') stagedFiles.push(data.data.message)
+  })
+
+  const staged = await Helper.pick(staging, [{ tag: 'staging' }, { tag: 'final' }])
+  const info = await staged.staging
+  await staged.final
+
+  is(info.name, null, 'staging name is null without a package.json')
+  ok(stagedFiles.includes('/index.js'), 'folder without package.json is staged')
+})
+
+test('pear stage does not walk up to a parent package.json', async ({
+  teardown,
+  ok,
+  absent,
+  tmp
+}) => {
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+
+  const tmpdir = await tmp()
+  const to = new Localdrive(tmpdir)
+  await to.put('/package.json', JSON.stringify({ name: 'parent', main: 'index.js' }))
+  await to.put('/index.js', 'module.exports = {}\n')
+  await to.put('/src/app.js', 'module.exports = {}\n')
+
+  const link = await Helper.touchLink(helper)
+  const staging = helper.stage({ link, dir: path.join(tmpdir, 'src'), dryRun: false })
+  teardown(() => Helper.teardownStream(staging))
+
+  const stagedFiles = []
+  staging.on('data', (data) => {
+    if (data?.tag === 'byte-diff') stagedFiles.push(data.data.message)
+  })
+
+  const staged = await Helper.pick(staging, [{ tag: 'final' }])
+  await staged.final
+
+  ok(stagedFiles.includes('/app.js'), 'subdirectory contents are staged')
+  absent(stagedFiles.includes('/package.json'), 'parent package.json is not staged')
+  absent(stagedFiles.includes('/index.js'), 'parent files are not staged')
+})
+
+test('pear stage with malformed package.json', async ({ teardown, is, fail, plan, tmp }) => {
+  plan(1)
+
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+
+  const tmpdir = await tmp()
+  const to = new Localdrive(tmpdir)
+  await to.put('/package.json', '{ "name": "malformed", }')
+
+  const link = await Helper.touchLink(helper)
+  const staging = helper.stage({ link, dir: tmpdir, dryRun: false })
+  teardown(() => Helper.teardownStream(staging))
+
+  try {
+    const staged = await Helper.pick(staging, [{ tag: 'final' }])
+    await staged.final
+    fail('stage should error on a malformed package.json')
+  } catch (err) {
+    is(err.code, 'ERR_INVALID_MANIFEST', 'malformed package.json errors')
+  }
+})
+
+test('pear stage with a package.json that is not a JSON object', async ({
+  teardown,
+  is,
+  fail,
+  plan,
+  tmp
+}) => {
+  plan(1)
+
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+
+  const tmpdir = await tmp()
+  const to = new Localdrive(tmpdir)
+  await to.put('/package.json', '[]')
+
+  const link = await Helper.touchLink(helper)
+  const staging = helper.stage({ link, dir: tmpdir, dryRun: false })
+  teardown(() => Helper.teardownStream(staging))
+
+  try {
+    const staged = await Helper.pick(staging, [{ tag: 'final' }])
+    await staged.final
+    fail('stage should error on a non-object package.json')
+  } catch (err) {
+    is(err.code, 'ERR_INVALID_MANIFEST', 'non-object package.json errors')
+  }
+})
+
+test('pear stage with a directory that does not exist', async ({
+  teardown,
+  is,
+  fail,
+  plan,
+  tmp
+}) => {
+  plan(1)
+
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+
+  const tmpdir = await tmp()
+  const link = await Helper.touchLink(helper)
+  const staging = helper.stage({ link, dir: path.join(tmpdir, 'missing'), dryRun: false })
+  teardown(() => Helper.teardownStream(staging))
+
+  try {
+    const staged = await Helper.pick(staging, [{ tag: 'final' }])
+    await staged.final
+    fail('stage should error on a directory that does not exist')
+  } catch (err) {
+    is(err.code, 'ERR_INVALID_PROJECT_DIR', 'missing directory errors')
+  }
+})
+
+test('pear stage with a file as the project directory', async ({
+  teardown,
+  is,
+  fail,
+  plan,
+  tmp
+}) => {
+  plan(1)
+
+  const helper = new Helper()
+  teardown(() => helper.close(), { order: Infinity })
+  await helper.ready()
+
+  const tmpdir = await tmp()
+  const to = new Localdrive(tmpdir)
+  await to.put('/index.js', 'module.exports = {}\n')
+
+  const link = await Helper.touchLink(helper)
+  const staging = helper.stage({ link, dir: path.join(tmpdir, 'index.js'), dryRun: false })
+  teardown(() => Helper.teardownStream(staging))
+
+  try {
+    const staged = await Helper.pick(staging, [{ tag: 'final' }])
+    await staged.final
+    fail('stage should error when the project directory is a file')
+  } catch (err) {
+    is(err.code, 'ERR_INVALID_PROJECT_DIR', 'file as project directory errors')
+  }
 })


### PR DESCRIPTION
 - Running `pear stage` from a subdirectory of a project no longer silently walks up and stages the project root — it stages the directory given.
  - A folder with no `package.json` can now be staged (with `pear` options defaulting to `{}`).