### PR TITLE
Support calling pear.dev from a symlink

### DIFF
--- a/pear.dev
+++ b/pear.dev
@@ -1,5 +1,7 @@
 #!/bin/sh
-root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+command -v realpath >/dev/null 2>&1 && script=$(realpath -- "$0") || script=$0
+
+root=$(CDPATH= cd -- "$(dirname -- "$script")" && pwd)
 bare="$root/node_modules/bare-runtime/bin/bare"
 
 if [ ! -e "$bare" ]; then

--- a/pear.dev
+++ b/pear.dev
@@ -1,4 +1,5 @@
 #!/bin/sh
+# NOTE: macOS only started shipping `realpath` in macOS 13 Ventura
 command -v realpath >/dev/null 2>&1 && script=$(realpath -- "$0") || script=$0
 
 root=$(CDPATH= cd -- "$(dirname -- "$script")" && pwd)


### PR DESCRIPTION
Before:
```
$ ln -s /path/to/pear.dev ~/.local/bin/pear.dev
$ pear.dev
Missing Bare runtime: /home/user/.local/bin/node_modules/bare-runtime/bin/bare
```

After:
```
$ pear.dev
Pear ~ Welcome to the Internet of Peers
...
```

Unsure if we should polyfill for pre-ventura macOS