### PR TITLE
Fix unknown arg error when running tests

### DIFF
--- a/lib/cmd.js
+++ b/lib/cmd.js
@@ -12,9 +12,9 @@ const definition = [
 
 module.exports = {
   definition,
-  command: (argv) =>
+  command: (argv, { bails = false } = {}) =>
     command('pear', ...definition, arg('[cmd]'), rest('rest')).parse(argv, {
       // Used only for bootstrap flag extraction. Defer unknown flags and other CLI errors to the main parser.
-      bails: false
+      bails
     })
 }

--- a/sidecar.js
+++ b/sidecar.js
@@ -32,7 +32,10 @@ async function bootSidecar() {
 
   const maxCacheSize = 65536
   const globalCache = new Rache({ maxSize: maxCacheSize })
-  const nodes = pear(cmdArgs.filter((arg) => arg !== 'sidecar'))
+  const nodes = pear(
+    cmdArgs.filter((arg) => arg !== 'sidecar'),
+    { bails: true }
+  )
     .flags.dhtBootstrap?.split(',')
     .map((tuple) => {
       const [host, port] = tuple.split(':')

--- a/test/helper.js
+++ b/test/helper.js
@@ -52,7 +52,7 @@ class Helper extends IPC.Client {
   static OUT = OUT
   // DO NOT UNDER ANY CIRCUMSTANCES ADD PUBLIC METHODS OR PROPERTIES TO HELPER (see pear-ipc)
   constructor(opts = {}) {
-    const logging = cmdArgs.filter((arg) => arg.startsWith('--log'))
+    const logging = cmdArgs.filter((arg) => arg.startsWith('--log-level'))
     const log = logging.length > 0
     const runtime = opts.platformDir
       ? path.resolve(opts.platformDir, '..', OUT)


### PR DESCRIPTION
Currently running tests with unknown args (such as the old --log-max) causes sidecar to throw a non-descript error:
```
2026-09-10T11:19:54.420Z ERR [ internal ] Sidecar Boot Failed TypeError: Cannot read properties of null (reading 'flags')
    at bootSidecar (file:///home/user/pear/sidecar.js:36:5)
```

This lets the correct error to be shown