### PR TITLE
seed: add field Verlink

### DIFF
--- a/cmd/seed.js
+++ b/cmd/seed.js
@@ -40,10 +40,11 @@ module.exports = async function seed(cmd) {
   const transformLength = ({ synced, length, isSynced }) => {
     const percentage = isSynced ? 100 : length === 0 ? 0 : Math.floor((synced / length) * 100)
     const blocks = isSynced ? length : `${synced}/${length}`
-    const blocksLabel = ctrlTTY ? String(blocks).padEnd(blocksWidth) : `${blocks} `
-    const progress = `${blocksLabel}[ ${percentage}% ]`
-    if (!ctrlTTY) return progress
-    return isSynced ? `${blocksLabel}${ansi.gray(`[ ${percentage}% ]`)}` : ansi.yellow(progress)
+    if (!ctrlTTY) return `${blocks} [ ${percentage}% ]`
+    const blocksLabel = String(blocks).padEnd(blocksWidth)
+    const percentageLabel = `[${String(percentage).padStart(3)}%]`
+    const progress = `${blocksLabel}${percentageLabel}`
+    return isSynced ? `${blocksLabel}${ansi.gray(percentageLabel)}` : ansi.yellow(progress)
   }
 
   const stats = new DictTable([
@@ -54,15 +55,14 @@ module.exports = async function seed(cmd) {
       transform: (v) => (ctrlTTY ? ansi.bold(ansi.green(v)) : v)
     },
     {
-      key: 'app',
-      label: ctrlTTY ? 'App:' : '... app',
+      key: 'verlink',
+      label: ctrlTTY ? 'Verlink:' : '... verlink',
       initial
     },
     {
-      key: 'driveKey',
-      label: ctrlTTY ? 'Drive Key:' : '... drive key',
-      initial,
-      transform: (v) => (ctrlTTY ? ansi.gray(v) : v)
+      key: 'app',
+      label: ctrlTTY ? 'App:' : '... app',
+      initial
     },
     {
       key: 'driveLength',
@@ -200,6 +200,7 @@ module.exports = async function seed(cmd) {
     stats({
       peers,
       driveKey,
+      driveFork,
       driveSynced,
       driveLength,
       blobsSynced,
@@ -224,7 +225,8 @@ module.exports = async function seed(cmd) {
       const blobsBlocks = isBlobsSynced ? blobsLength : `${blobsSynced}/${blobsLength}`
       blocksWidth = Math.max(String(driveBlocks).length, String(blobsBlocks).length) + 1
       stats.update({
-        driveKey: hypercoreid.normalize(driveKey),
+        verlink: `pear://${driveFork}.${driveLength}.${driveKey}`,
+        app: `${name ?? ''}${semver ? `@${semver}` : ''}` || '-',
         driveLength: {
           synced: driveSynced,
           length: driveLength,
@@ -236,7 +238,6 @@ module.exports = async function seed(cmd) {
           isSynced: isBlobsSynced
         },
         blobsByteLength,
-        app: `${name ?? ''}${semver ? `@${semver}` : ''}` || '-',
         discoveryKey: hypercoreid.normalize(discoveryKey),
         contentKey: hypercoreid.isValid(contentKey)
           ? hypercoreid.normalize(contentKey)

--- a/subsystems/sidecar/ops/seed.js
+++ b/subsystems/sidecar/ops/seed.js
@@ -27,6 +27,7 @@ module.exports = class Seed extends Opstream {
         firewalled: dht.bootstrapped ? (dht.firewalled ? true : false) : undefined,
         peers: core.peers.length,
         driveKey: drive.key ? hypercoreid.encode(drive.key) : undefined,
+        driveFork: core.fork,
         driveSynced: core.core.bitfield.countSet(0, core.length) ?? 0,
         driveLength: core.length ?? 0,
         blobsSynced: blobs?.core.bitfield.countSet(0, blobs.length) ?? 0,

--- a/test/seed.test.js
+++ b/test/seed.test.js
@@ -15,7 +15,7 @@ test('pear seed basic stage and seed', async function ({
   timeout
 }) {
   timeout(180000)
-  plan(18)
+  plan(19)
 
   const dir = Helper.fixture('versions')
 
@@ -53,6 +53,7 @@ test('pear seed basic stage and seed', async function ({
 
   const stats = await until.stats
   is(stats.driveKey, hypercoreid.normalize(stats.driveKey), 'stats driveKey is z32')
+  ok(Number.isInteger(stats.driveFork), 'stats have driveFork')
   is(stats.driveLength, addendum.version, 'stats have driveLength')
   ok(Number.isInteger(stats.blobsByteLength), 'stats have blobsByteLength')
   is(stats.name, 'versions', 'stats have package name')


### PR DESCRIPTION
* Added field `Verlink` (realtime)
* Removed from TTY mode field `Drive Key` (redundant, key already appears twice), present at ops/json

<img width="748" height="294" alt="image" src="https://github.com/user-attachments/assets/117973d1-853b-446d-a44e-f9152b3f6930" />

---

* Sub-task: Percentage UI alignment to the right

<img width="578" height="42" alt="Screenshot 2026-09-10 at 14 13 11" src="https://github.com/user-attachments/assets/2094d32a-95e7-4e36-83cc-0940282d0f12" />

---

<img width="577" height="44" alt="Screenshot 2026-09-10 at 14 16 33" src="https://github.com/user-attachments/assets/240f2516-fdd5-47be-a989-0e06b7bcbde4" />

---

<img width="575" height="45" alt="Screenshot 2026-09-10 at 15 46 34" src="https://github.com/user-attachments/assets/4862018d-293e-452a-87b7-84153c3918d8" />
